### PR TITLE
Fix Spelling error, untit:unit in skeleton simpletest example

### DIFF
--- a/lib/Drupal/AppConsole/Resources/skeleton/module/module.tests.twig
+++ b/lib/Drupal/AppConsole/Resources/skeleton/module/module.tests.twig
@@ -17,7 +17,7 @@ class {{module}}Test extends WebTestBase {
   public static function getInfo() {
     return array(
       'name' => '{{module}} functionality',
-      'description' => 'Test Untit for module {{module}}.',
+      'description' => 'Test Unit for module {{module}}.',
       'group' => 'Other',
     );
   }


### PR DESCRIPTION
Minor fix.  :)
