### PR TITLE
Remove user-specific gitignore declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,11 +9,3 @@
 
 # Test
 /phpunit.xml
-
-# IDEs
-.idea
-/nbproject
-
-# OS
-.DS_Store
-Thumbs.db


### PR DESCRIPTION
Any user-specific declaration should not appear in
a project .gitignore.

Consider adding it to the user global .gitignore instead.

More info
http://bit.ly/user-specific-gitignore
