### PR TITLE
Remove unused twig files

### DIFF
--- a/src/Resources/skeleton/module/shared/services-class-properties-declaration.php.twig
+++ b/src/Resources/skeleton/module/shared/services-class-properties-declaration.php.twig
@@ -1,7 +1,0 @@
-{% for service in services %}
-  /**
-   * @var {{ service.class }}
-   */
-  protected ${{service.machine_name}};
-  
-{% endfor %}

--- a/src/Resources/skeleton/module/shared/services-class-properties-initialization.php.twig
+++ b/src/Resources/skeleton/module/shared/services-class-properties-initialization.php.twig
@@ -1,3 +1,0 @@
-{% for service in services %}
-    $this->{{service.machine_name}} = ${{service.machine_name}};
-{% endfor %}

--- a/src/Resources/skeleton/module/shared/services-class-properties-injection.php.twig
+++ b/src/Resources/skeleton/module/shared/services-class-properties-injection.php.twig
@@ -1,4 +1,0 @@
-{% for service in services %}
-      $container->get('{{service.name}}'){% if loop.last == false %},{{"\n"}}{% endif %}
-{% endfor %}
-

--- a/src/Resources/skeleton/module/shared/services-use-operator.php.twig
+++ b/src/Resources/skeleton/module/shared/services-use-operator.php.twig
@@ -1,9 +1,0 @@
-{% if useContainerInterface is not defined %}
-{% set useContainerInterface = true %}
-{% endif %}
-{% if useContainerInterface %}
-use Symfony\Component\DependencyInjection\ContainerInterface;
-{% endif %}
-{% for service in services %}
-use {{ service.class }};
-{% endfor %}


### PR DESCRIPTION
Removed files:
- services-class-properties-declaration.php.twig
- services-class-properties-initialization.php.twig
- services-class-properties-injection.php.twig
- services-use-operator.php.twig
