### PR TITLE
Modify names of tasks, actions and menu files

### DIFF
--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -33,21 +33,21 @@ class EntityContentGenerator extends Generator
       
     $this->renderFile(
       'module/menu_links-entity.yml.twig',
-      $this->getModulePath($module).'/'.$module.'.menu_links.yml',
+      $this->getModulePath($module).'/'.$module.'.links.menu.yml',
       $parameters,
       FILE_APPEND
     );
       
     $this->renderFile(
       'module/local_tasks-entity.yml.twig',
-      $this->getModulePath($module).'/'.$module.'.local_tasks.yml',
+      $this->getModulePath($module).'/'.$module.'.links.task.yml',
       $parameters,
       FILE_APPEND
     );
 
     $this->renderFile(
       'module/local_actions-entity-content.yml.twig',
-      $this->getModulePath($module).'/'.$module.'.local_actions.yml',
+      $this->getModulePath($module).'/'.$module.'.links.action.yml',
       $parameters,
       FILE_APPEND
     );


### PR DESCRIPTION
This PR solve the issue #166 respect to generate content-entities
The name of files to define tasks, actions and menu links recently was changed
review the community documentation:
https://www.drupal.org/node/2192175
