### PR TITLE
Update form.php.twig

### DIFF
--- a/src/Resources/skeleton/module/src/Form/form.php.twig
+++ b/src/Resources/skeleton/module/src/Form/form.php.twig
@@ -85,7 +85,7 @@ class {{ class_name }} extends ConfigFormBase
 
     $this->config('{{module_name}}.{{form_id}}_config')
     {% for input in inputs %}
-      ->set('{{ input.name }}', $form_state->getValue(['{{ input.name }}']))
+      ->set('{{ input.name }}', $form_state->getValue('{{ input.name }}'))
     {% endfor %}
     ->save();
   }


### PR DESCRIPTION
As per https://www.drupal.org/node/2310411

$foo = $form_state['values']['foo']; 

should now be

$foo = $form_state->getValue('foo');
