### PR TITLE
Rollback twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/console": "2.5.*",
         "symfony/finder": "2.5.*",
         "symfony/dependency-injection": "2.5.*",
-        "twig/twig": "1.16.*",
+        "twig/twig": "1.15.*",
         "composer/installers": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
- Set drupal/drupal version to 8.0.0-beta2
- Set twig/twig to version 1.15.*
