### PR TITLE
Config entity properties should be protected.

### DIFF
--- a/src/Resources/skeleton/module/src/Entity/entity.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/entity.php.twig
@@ -50,18 +50,13 @@ class {{ entity_class }} extends ConfigEntityBase implements {{ entity_class }}I
    *
    * @var string
    */
-  public $id;
-  /**
-   * The {{ entity_class }} UUID.
-   *
-   * @var string
-   */
-  public $uuid;
+  protected $id;
+
   /**
    * The {{ entity_class }} label.
    *
    * @var string
    */
-  public $label;
+  protected $label;
 
 {% endblock %}


### PR DESCRIPTION
Core has converted all config entity types to use protected properties.
Instead of accessing $id and $label directly, callers are supposed to use ->id() and ->label().
This is already the case in the generated list builders and forms.

I've fixed the class template, and removed the $uuid property completely, since it is defined by the parent ConfigEntityBase.
