### PR TITLE
Fix non-existent 'exists' callback declared in the config entity form.

### DIFF
--- a/src/Resources/skeleton/module/src/Form/entity.php.twig
+++ b/src/Resources/skeleton/module/src/Form/entity.php.twig
@@ -39,7 +39,7 @@ class {{ entity_class }}Form extends EntityForm
       '#type' => 'machine_name',
       '#default_value' => ${{ entity_name }}->id(),
       '#machine_name' => array(
-        'exists' => '{{ entity_name }}_load',
+        'exists' => '\Drupal\{{ module }}\Entity\{{ entity_class }}::load',
       ),
       '#disabled' => !${{ entity_name }}->isNew(),
     );


### PR DESCRIPTION
Generating a "workflow" entity type gave me an exists callback that pointed to "workflow_load", which is a wrapper for entity_load that isn't generated (and isn't a best practise to have anymore).

I've implemented what Commerce does instead. Core either uses the same approach, or injects the entity storage and calls its load method.
