### PR TITLE
Standardize config entity routes.

### DIFF
--- a/src/Resources/skeleton/module/links.action-entity.yml.twig
+++ b/src/Resources/skeleton/module/links.action-entity.yml.twig
@@ -1,6 +1,6 @@
-{{ entity_name }}.add:
-  route_name: '{{ entity_name }}.add'
+entity.{{ entity_name }}.add_form:
+  route_name: 'entity.{{ entity_name }}.add_form'
   title: 'Add {{ entity_class }}'
   appears_on:
-    - {{ entity_name }}.list
+    - entity.{{ entity_name }}.list
 

--- a/src/Resources/skeleton/module/routing-entity.yml.twig
+++ b/src/Resources/skeleton/module/routing-entity.yml.twig
@@ -1,5 +1,5 @@
 # {{ entity_class }} routing definition
-{{ entity_name }}.list:
+entity.{{ entity_name }}.list:
   path: '/admin/config/system/{{ entity_name }}'
   defaults:
     _entity_list: '{{ entity_name }}'
@@ -7,7 +7,7 @@
   requirements:
     _permission: 'administer site configuration'
 
-{{ entity_name }}.add:
+entity.{{ entity_name }}.add_form:
   path: '/admin/config/system/{{ entity_name }}/add'
   defaults:
     _entity_form: '{{ entity_name }}.add'
@@ -15,7 +15,7 @@
   requirements:
     _permission: 'administer site configuration'
 
-{{ entity_name }}.edit:
+entity.{{ entity_name }}.edit_form:
   path: '/admin/config/system/{{ entity_name }}/{{ '{'~entity_name~'}' }}'
   defaults:
     _entity_form: '{{ entity_name }}.edit'
@@ -23,7 +23,7 @@
   requirements:
     _permission: 'administer site configuration'
 
-{{ entity_name }}.delete:
+entity.{{ entity_name }}.delete_form:
   path: '/admin/config/system/{{ entity_name }}/{{ '{'~entity_name~'}' }}/delete'
   defaults:
     _entity_form: '{{ entity_name }}.delete'

--- a/src/Resources/skeleton/module/src/Entity/entity.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/entity.php.twig
@@ -36,8 +36,8 @@ use Drupal\{{ module }}\{{ entity_class }}Interface;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "{{ entity_name }}.edit",
- *     "delete-form" = "{{ entity_name }}.delete"
+ *     "edit-form" = "entity.{{ entity_name }}.edit_form",
+ *     "delete-form" = "entity.{{ entity_name }}.delete_form"
  *   }
  * )
  */

--- a/src/Resources/skeleton/module/src/Form/entity-delete.php.twig
+++ b/src/Resources/skeleton/module/src/Form/entity-delete.php.twig
@@ -33,7 +33,7 @@ class {{ entity_class }}DeleteForm extends EntityConfirmFormBase
   * {@inheritdoc}
   */
   public function getCancelUrl() {
-    return new Url('{{ entity_name }}.list');
+    return new Url('entity.{{ entity_name }}.list');
   }
 
   /**

--- a/src/Resources/skeleton/module/src/Form/entity.php.twig
+++ b/src/Resources/skeleton/module/src/Form/entity.php.twig
@@ -66,6 +66,6 @@ class {{ entity_class }}Form extends EntityForm
         '%label' => ${{ entity_name }}->label(),
       )));
     }
-    $form_state->setRedirect('{{ entity_name }}.list');
+    $form_state->setRedirect('entity.{{ entity_name }}.list');
   }
 {% endblock %}


### PR DESCRIPTION
Core has standardized the entity route names to match their relationships.
This means that "$entity_type.edit" becomes "entity.$entity_type.edit_form", same for add and delete.
Change notice: https://www.drupal.org/node/2306387

This change did not include the list route, even though it is a needed change as well.
I've talked to Berdir, who confirmed that the current best practise is to use "entity.$entity_type.list", so I've implemented that. It makes the generated routes nice and consistent.

The same change needs to happen for the generated content entities, but doing it for config entities allows us to start small. 
For content entity types we also need to rename the "view" route to "canonical", and remove the admin-form link from the entity annotation (it has been renamed to field_ui_base_route and is no longer suitable for pointing to a settings page).
