### PR TITLE
Standardize content entity routes.

### DIFF
--- a/src/Resources/skeleton/module/links.action-entity-content.yml.twig
+++ b/src/Resources/skeleton/module/links.action-entity-content.yml.twig
@@ -1,6 +1,6 @@
-{{ entity_name }}.add:
-  route_name: {{ entity_name }}.add
+entity.{{ entity_name }}.add_form:
+  route_name: entity.{{ entity_name }}.add_form
   title: 'Add {{ entity_class }}'
   appears_on:
-    - {{ entity_name }}.list
-    - {{ entity_name }}.view
+    - entity.{{ entity_name }}.list
+    - entity.{{ entity_name }}.canonical

--- a/src/Resources/skeleton/module/links.menu-entity-content.yml.twig
+++ b/src/Resources/skeleton/module/links.menu-entity-content.yml.twig
@@ -1,7 +1,7 @@
 # {{ entity_class }} menu items definition
-{{ entity_name }}.list:
+entity.{{ entity_name }}.list:
   title: '{{ entity_class }}: Listing'
-  route_name: {{ entity_name }}.list
+  route_name: entity.{{ entity_name }}.list
   description: 'List {{ entity_class }}'
 
 {{ entity_name }}.admin.structure.settings:

--- a/src/Resources/skeleton/module/links.task-entity-content.yml.twig
+++ b/src/Resources/skeleton/module/links.task-entity-content.yml.twig
@@ -4,17 +4,17 @@
   title: 'Settings'
   base_route: {{ entity_name }}.settings
 
-{{ entity_name }}.view:
-  route_name: {{ entity_name }}.view
-  base_route: {{ entity_name }}.view
+entity.{{ entity_name }}.canonical:
+  route_name: entity.{{ entity_name }}.canonical
+  base_route: entity.{{ entity_name }}.canonical
   title: 'View'
 
-{{ entity_name }}.edit:
-  route_name: {{ entity_name }}.edit
-  base_route: {{ entity_name }}.view
+entity.{{ entity_name }}.edit_form:
+  route_name: entity.{{ entity_name }}.edit_form
+  base_route: entity.{{ entity_name }}.canonical
   title: Edit
 
-{{ entity_name }}.delete_confirm:
-  route_name:  {{ entity_name }}.delete
-  base_route:  {{ entity_name }}.view
+entity.{{ entity_name }}.delete_form:
+  route_name:  entity.{{ entity_name }}.delete_form
+  base_route:  entity.{{ entity_name }}.canonical
   title: Delete

--- a/src/Resources/skeleton/module/routing-entity-content.yml.twig
+++ b/src/Resources/skeleton/module/routing-entity-content.yml.twig
@@ -1,5 +1,5 @@
 # {{ entity_class }} routing definition
-{{ entity_name }}.view:
+entity.{{ entity_name }}.canonical:
   path: '/admin/{{ entity_name }}/{{ '{'~entity_name~'}' }}'
   defaults:
     _entity_view: '{{ entity_name }}'
@@ -7,7 +7,7 @@
   requirements:
     _entity_access: '{{ entity_name }}.view'
 
-{{ entity_name }}.list:
+entity.{{ entity_name }}.list:
   path: '/admin/{{ entity_name }}'
   defaults:
     _entity_list: '{{ entity_name }}'
@@ -15,7 +15,7 @@
   requirements:
     _permission: 'view {{ entity_class }} entity'
 
-{{ entity_name }}.add:
+entity.{{ entity_name }}.add_form:
   path: '/admin/{{ entity_name }}/add'
   defaults:
     _entity_form: {{ entity_name }}.add
@@ -23,7 +23,7 @@
   requirements:
     _entity_create_access: '{{ entity_name }}'
 
-{{ entity_name }}.edit:
+entity.{{ entity_name }}.edit_form:
   path: '/admin/{{ entity_name }}/{{ '{'~entity_name~'}' }}/edit'
   defaults:
     _entity_form: {{ entity_name }}.edit
@@ -31,7 +31,7 @@
   requirements:
     _entity_access: '{{ entity_name }}.edit'
 
-{{ entity_name }}.delete:
+entity.{{ entity_name }}.delete_form:
   path: '/admin/{{ entity_name }}/{{ '{'~entity_name~'}' }}/delete'
   defaults:
     _entity_form: {{ entity_name }}.delete

--- a/src/Resources/skeleton/module/src/Entity/Controller/listcontroller-entity-content.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/Controller/listcontroller-entity-content.php.twig
@@ -42,7 +42,7 @@ class {{ entity_class }}ListController extends EntityListBuilder
     $row['name'] = \Drupal::l(
         $this->getLabel($entity),
         new Url(
-          '{{ entity_name }}.edit', array(
+          'entity.{{ entity_name }}.edit_form', array(
             '{{ entity_name }}' => $entity->id(),
         )
       )

--- a/src/Resources/skeleton/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/Form/entity-content-delete.php.twig
@@ -35,7 +35,7 @@ class {{ entity_class }}DeleteForm extends ContentEntityConfirmFormBase
    * {@inheritdoc}
    */
   public function getCancelUrl() {
-    return new Url('{{ entity_name }}.list');
+    return new Url('entity.{{ entity_name }}.list');
   }
 
   /**

--- a/src/Resources/skeleton/module/src/Entity/Form/entity-content.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/Form/entity-content.php.twig
@@ -69,6 +69,6 @@ class {{ entity_class }}Form extends ContentEntityForm
         '%label' => $entity->label(),
       )));
     }
-    $form_state->setRedirect('{{ entity_name }}.edit', ['{{ entity_name }}' => $entity->id()]);
+    $form_state->setRedirect('entity.{{ entity_name }}.edit_form', ['{{ entity_name }}' => $entity->id()]);
   }
 {% endblock %}

--- a/src/Resources/skeleton/module/src/Entity/entity-content.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/entity-content.php.twig
@@ -47,10 +47,9 @@ use Drupal\user\UserInterface;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "canonical" = "{{ entity_name }}.view",
- *     "edit-form" = "{{ entity_name }}.edit",
- *     "admin-form" = "{{ entity_name }}.settings",
- *     "delete-form" = "{{ entity_name }}.delete"
+ *     "canonical" = "entity.{{ entity_name }}.canonical",
+ *     "edit-form" = "entity.{{ entity_name }}.edit_form",
+ *     "delete-form" = "entity.{{ entity_name }}.delete_form"
  *   },
  *   field_ui_base_route = "{{ entity_name }}.settings"
  * )


### PR DESCRIPTION
Same story as for #253.

As I wrote there:

> For content entity types we also need to rename the "view" route to "canonical", and remove the admin-form link from the entity annotation (it has been renamed to field_ui_base_route and is no longer suitable for pointing to a settings page).
