### PR TITLE
.install generator

### DIFF
--- a/Test/Command/GeneratorInstallCommandTest.php
+++ b/Test/Command/GeneratorInstallCommandTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @file
- * Contains \Drupal\AppConsole\Test\Command\GeneratorPermissionCommandTest.
+ * Contains \Drupal\AppConsole\Test\Command\GeneratorInstallCommandTest.
  */
 
 namespace Drupal\AppConsole\Test\Command;
 
 use Symfony\Component\Console\Tester\CommandTester;
 
-class GeneratorPermissionCommandTest extends GenerateCommandTest
+class GeneratorInstallCommandTest extends GenerateCommandTest
 {
     /**
      * @dataProvider getInteractiveData
@@ -19,13 +19,13 @@ class GeneratorPermissionCommandTest extends GenerateCommandTest
      */
     public function testInteractive($options, $expected, $input)
     {
+        list($module, $table_name, $table_description, $columns, $primary_key, $indexes) = $expected;
 
-        list($module, $permissions) = $expected;
         $generator = $this->getGenerator();
         $generator
           ->expects($this->once())
           ->method('generate')
-          ->with($module, $permissions);
+          ->with($module, $table_name, $table_description, $columns, $primary_key, $indexes);
 
         $command = $this->getCommand($generator, $input);
         $cmd = new CommandTester($command);
@@ -34,10 +34,29 @@ class GeneratorPermissionCommandTest extends GenerateCommandTest
 
     public function getInteractiveData()
     {
-        $permissions = [
+        $columns = [
           [
-            'permission' => 'my permission',
-            'permission_title' => 'My permission',
+            'column_name' => 'bar',
+            'column_type' => 'int',
+            'column_type_options' => '',
+            'column_unsigned' => TRUE,
+            'column_not_null' => TRUE,
+            'column_default' => 0,
+            'column_size' => 'tiny',
+            'column_description' => 'Baz',
+//            'primary_key' => 'bar',
+//            'indexes' => 'bar',
+          ]
+        ];
+        $primary_key = [
+          [
+            'primary_key' => 'bar',
+          ]
+        ];
+        $indexes = [
+          [
+            'index_name_key' => 'bar',
+            'index_name_value' => 'bar',
           ]
         ];
 
@@ -47,26 +66,26 @@ class GeneratorPermissionCommandTest extends GenerateCommandTest
               // Inline options
             [],
               // Expected options
-            ['foo', $permissions, true],
+            ['foo', 'Description', $columns, $primary_key, $indexes],
               // User input options
-            "foo\nyes\nMy Permission\n",
+            "foo\nDescription\nyes\nbar\nint\nTRUE\nTRUE\n0\ntiny\nBaz\nyes\nbar\nyes\nbar\nbar\n",
           ],
-            // case two
-          [
-              // Inline options
-            ['--module' => 'foo'],
-              // Expected options
-            ['foo', $permissions, true],
-              // User input options
-            "foo\nyes\nMy Permission\n",
-          ],
+//            // case two
+//          [
+//              // Inline options
+//            ['--module' => 'foo'],
+//              // Expected options
+//            ['foo', $inputs, true],
+//              // User input options
+//            "foo\nyes\nMy Permission\n",
+//          ],
         ];
     }
 
     protected function getCommand($generator, $input)
     {
         $command = $this
-          ->getMockBuilder('Drupal\AppConsole\Command\GeneratorPermissionCommand')
+          ->getMockBuilder('Drupal\AppConsole\Command\GeneratorInstallCommand')
           ->setMethods(['getModules', '__construct'])
           ->setConstructorArgs([$this->getTranslationHelper()])
           ->getMock();
@@ -85,7 +104,7 @@ class GeneratorPermissionCommandTest extends GenerateCommandTest
     private function getGenerator()
     {
         return $this
-          ->getMockBuilder('Drupal\AppConsole\Generator\PermissionGenerator')
+          ->getMockBuilder('Drupal\AppConsole\Generator\InstallGenerator')
           ->disableOriginalConstructor()
           ->setMethods(['generate'])
           ->getMock();

--- a/Test/Command/GeneratorPermissionCommandTest.php
+++ b/Test/Command/GeneratorPermissionCommandTest.php
@@ -30,7 +30,6 @@ class GeneratorPermissionCommandTest extends GenerateCommandTest
 
     public function getInteractiveData()
     {
-
         $permissions = [
           [
             'permission' => 'my permission',

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -22,6 +22,7 @@ commands:
       inputs: Create inputs in a form.
       permissions: Create permissions.
       columns: Create columns.
+      primary-key: Create primary key.
     questions:
       module: Enter the module name
       confirm: Do you confirm generation
@@ -57,6 +58,9 @@ commands:
         column_default_invalid: Default Type "%s" is invalid. Must be '', 0, 1 or None.
         column_size_invalid: Size Type "%s" is invalid.
         column_description: Column Description
+        confirm_primary_key: Do you want to generate a primary key
+        table_primary_key: Enter primary keys. Multivalued primary keys separated by commas.
+        table_primary_key_invalid: One or more of the entered columns are invalid.
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -185,7 +185,7 @@ commands:
         columns: common.options.columns
       questions:
         module: common.questions.module
-        table-name: The table name
+        table-name: Enter the table name
         columns: common.questions.columns
     module:
       description: Generate a module.

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -44,9 +44,14 @@ commands:
       columns:
         confirm: Do you want to generate columns
         column_name: Column name
+        column_unsigned: Unsigned or signed
+        column_not_null: Not null or null
+        column_default: Default
         column_type: Type
-#        column_type: Input column type
         column_invalid: Column Type "%s" is invalid.
+        column_unsigned_invalid: Unsigned Type "%s" is invalid. Must be TRUE, FALSE, or None.
+        column_not_null_invalid: Null Type "%s" is invalid. Must be TRUE, FALSE, or None.
+        column_default_invalid: Default Type "%s" is invalid. Must be '', 0, 1 or None.
         column_description: Column Description
     errors:
       module-dependency: Missing module dependency "%s"

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -22,7 +22,8 @@ commands:
       inputs: Create inputs in a form.
       permissions: Create permissions.
       columns: Create columns.
-      primary-key: Create primary key.
+      primary-key: Create a primary key.
+      index: Create an index or indexes.
     questions:
       module: Enter the module name
       confirm: Do you confirm generation
@@ -59,8 +60,11 @@ commands:
         column_size_invalid: Size Type "%s" is invalid.
         column_description: Column Description
         confirm_primary_key: Do you want to generate a primary key
-        table_primary_key: Enter primary keys. Multivalued primary keys separated by commas.
+        table_primary_key: Enter a primary key. Multivalued primary keys separated by commas or spaces.
         table_primary_key_invalid: Primary key requires a value.
+        confirm_table_index: Do you want to generate a index(es)
+        table_index: Enter indexes. Multivalued indexes separated by commas or spaces.
+        table_index_invalid: Index requires a value.
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -21,6 +21,7 @@ commands:
       tags: Set service tags from the container.
       inputs: Create inputs in a form.
       permissions: Create permissions.
+      column_inputs: Create columns.
     questions:
       module: Enter the module name
       confirm: Do you confirm generation
@@ -40,6 +41,13 @@ commands:
         type: Type
         invalid: Field Type "%s" is invalid.
         description: Description
+      column_inputs:
+        confirm: Do you want to generate a columns
+        column_name: Column name
+        column_type: Type
+#        column_type: Input column type
+        column_invalid: Column Type "%s" is invalid.
+        column_description: Column Description
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty
@@ -167,6 +175,18 @@ commands:
         services: common.questions.services
         inputs: common.questions.inputs
         routing: Update routing file
+    column:
+      description: Generate a custom table.
+      help: The <info>generate:install</info> command helps you generate a new custom table.
+      welcome: Welcome to the Drupal form generator
+      options:
+        module: common.options.module
+        table-name: Enter the table name
+        column_inputs: common.options.column_inputs
+      questions:
+        module: common.questions.module
+        table-name: The table name
+        column_inputs: common.questions.column_inputs
     module:
       description: Generate a module.
       help: The <info>generate:module</info> command helps you generates a new module.
@@ -196,14 +216,14 @@ commands:
       errors:
         directory-exists: The target directory "%s" is not empty.
     permission:
-        description: Generate module permissions
-        help: The <info>generate:permissions</info> command helps you generate new permissions
-        options:
-          module: common.options.module
-          permission: Enter a permission
-        questions:
-          module: common.questions.module
-          permission: Enter a permission
+      description: Generate module permissions
+      help: The <info>generate:permissions</info> command helps you generate new permissions
+      options:
+        module: common.options.module
+        permission: Enter a permission
+      questions:
+        module: common.questions.module
+        permission: Enter a permission
     plugin:
       block:
         description: Generate a plugin block

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -65,7 +65,7 @@ commands:
         confirm_table_index: Do you want to generate a index(es)
         confirm_index: Do you want to generate index(es)
         index_name: Enter an index. Multivalued indexes separated by commas or spaces.
-        index_name_invalid: Index requires a value.
+        index_name_invalid: The index requires a value.
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -60,7 +60,7 @@ commands:
         column_description: Column Description
         confirm_primary_key: Do you want to generate a primary key
         table_primary_key: Enter primary keys. Multivalued primary keys separated by commas.
-        table_primary_key_invalid: One or more of the entered columns are invalid.
+        table_primary_key_invalid: Primary key requires a value.
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -56,7 +56,7 @@ commands:
         column_not_null_invalid: Null Type "%s" is invalid. Must be TRUE, FALSE, or None.
         column_default_invalid: Default Type "%s" is invalid. Must be '', 0, 1 or None.
         column_size_invalid: Size Type "%s" is invalid.
-        column_description: Description
+        column_description: Column Description
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty
@@ -192,12 +192,12 @@ commands:
         module: common.options.module
         table-name: Enter the table's name
 #        To Do: Make table's Dynamic
-        table-description: Enter the table's description. Hit enter to exclude.
+        table-description: Enter the table's description.
         columns: common.options.columns
       questions:
         module: common.questions.module
         table-name: Enter the table's name
-        table-description: Enter the table's description. Hit enter to exclude.
+        table-description: Enter the table's description.
         columns: common.questions.columns
     module:
       description: Generate a module.

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -21,7 +21,7 @@ commands:
       tags: Set service tags from the container.
       inputs: Create inputs in a form.
       permissions: Create permissions.
-      column_inputs: Create columns.
+      columns: Create columns.
     questions:
       module: Enter the module name
       confirm: Do you confirm generation
@@ -39,10 +39,10 @@ commands:
         machine_name: Input machine name
         permission: Do you want to generate permissions
         type: Type
-        invalid: Field Type "%s" is invalid.
+        invalid: Column Type "%s" is invalid.
         description: Description
-      column_inputs:
-        confirm: Do you want to generate a columns
+      columns:
+        confirm: Do you want to generate columns
         column_name: Column name
         column_type: Type
 #        column_type: Input column type
@@ -182,11 +182,11 @@ commands:
       options:
         module: common.options.module
         table-name: Enter the table name
-        column_inputs: common.options.column_inputs
+        columns: common.options.columns
       questions:
         module: common.questions.module
         table-name: The table name
-        column_inputs: common.questions.column_inputs
+        columns: common.questions.columns
     module:
       description: Generate a module.
       help: The <info>generate:module</info> command helps you generates a new module.

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -199,14 +199,13 @@ commands:
       welcome: Welcome to the Drupal form generator
       options:
         module: common.options.module
-        table-name: Enter the table's name
-#        To Do: Make table's Dynamic
-        table-description: Enter the table's description.
+        table-name: Enter the table name
+        table-description: Enter the table description.
         columns: common.options.columns
       questions:
         module: common.questions.module
-        table-name: Enter the table's name
-        table-description: Enter the table's description.
+        table-name: Enter the table name
+        table-description: Enter the table description.
         columns: common.questions.columns
     module:
       description: Generate a module.

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -23,7 +23,7 @@ commands:
       permissions: Create permissions.
       columns: Create columns.
       primary-key: Create a primary key.
-      index: Create an index or indexes.
+      indexes: Create an index or indexes.
     questions:
       module: Enter the module name
       confirm: Do you confirm generation
@@ -63,8 +63,9 @@ commands:
         table_primary_key: Enter a primary key. Multivalued primary keys separated by commas or spaces.
         table_primary_key_invalid: Primary key requires a value.
         confirm_table_index: Do you want to generate a index(es)
-        table_index: Enter indexes. Multivalued indexes separated by commas or spaces.
-        table_index_invalid: Index requires a value.
+        confirm_index: Do you want to generate index(es)
+        index_name: Enter an index. Multivalued indexes separated by commas or spaces.
+        index_name_invalid: Index requires a value.
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -47,12 +47,16 @@ commands:
         column_unsigned: Unsigned or signed
         column_not_null: Not null or null
         column_default: Default
+        column_size: Size
         column_type: Type
-        column_invalid: Column Type "%s" is invalid.
+        column_length: Length
+        column_type_invalid: Column Type "%s" is invalid.
+        column_length_invalid: Column Length "%s" is invalid.
         column_unsigned_invalid: Unsigned Type "%s" is invalid. Must be TRUE, FALSE, or None.
         column_not_null_invalid: Null Type "%s" is invalid. Must be TRUE, FALSE, or None.
         column_default_invalid: Default Type "%s" is invalid. Must be '', 0, 1 or None.
-        column_description: Column Description
+        column_size_invalid: Size Type "%s" is invalid.
+        column_description: Description
     errors:
       module-dependency: Missing module dependency "%s"
       class-name-empty: The Class name can not be empty
@@ -186,11 +190,14 @@ commands:
       welcome: Welcome to the Drupal form generator
       options:
         module: common.options.module
-        table-name: Enter the table name
+        table-name: Enter the table's name
+#        To Do: Make table's Dynamic
+        table-description: Enter the table's description. Hit enter to exclude.
         columns: common.options.columns
       questions:
         module: common.questions.module
-        table-name: Enter the table name
+        table-name: Enter the table's name
+        table-description: Enter the table's description. Hit enter to exclude.
         columns: common.questions.columns
     module:
       description: Generate a module.

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -76,12 +76,12 @@ class GeneratorInstallCommand extends GeneratorCommand
         $input->setOption('table-name', $table_name);
 
         // --column options
-        $inputs = $input->getOption('columns');
-        if (!$inputs) {
+        $columns = $input->getOption('columns');
+        if (!$columns) {
             // @see \Drupal\AppConsole\Command\Helper\InstallTrait::installQuestion
-            $inputs = $this->installQuestion($output, $dialog);
+            $columns = $this->installQuestion($output, $dialog);
         }
-        $input->setOption('columns', $inputs);
+        $input->setOption('columns', $columns);
     }
 
     /**

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -39,8 +39,8 @@ class GeneratorInstallCommand extends GeneratorCommand
             $this->trans('commands.common.options.columns'))
           ->addOption('primary-key', '', InputOption::VALUE_OPTIONAL,
             $this->trans('commands.common.options.primary-key'))
-          ->addOption('index', '', InputOption::VALUE_OPTIONAL,
-            $this->trans('commands.common.options.index'));
+          ->addOption('indexes', '', InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.common.options.indexes'));
     }
 
     /**
@@ -53,12 +53,12 @@ class GeneratorInstallCommand extends GeneratorCommand
         $table_description = $input->getOption('table-description');
         $columns = $input->getOption('columns');
         $primary_key = $input->getOption('primary-key');
-        $index = $input->getOption('index');
+        $indexes = $input->getOption('indexes');
 
         $this
           ->getGenerator()
           ->generate($module, $table_name, $table_description, $columns,
-            $primary_key, $index);
+            $primary_key, $indexes);
     }
 
     /**
@@ -154,48 +154,21 @@ class GeneratorInstallCommand extends GeneratorCommand
 
         $input->setOption('primary-key', $primary_key_options);
 
-        // --index options
-        $index = $input->getOption('index');
-        if (!$index) {
-            if ($dialog->askConfirmation(
-              $output,
-              $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm_table_index'),
-                'yes', '?'),
-              true
-            )
-            ) {
-                while (true) {
-                    $index_options = $dialog->askAndValidate(
-                      $output,
-                      $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.table_index'),
-                        $column_names_string, ':'),
-                      function ($primary_key_choices) use ($column_names) {
-                          $primary_key_choices = $this->getStringUtils()
-                            ->camelCaseToCommaSeparated($primary_key_choices);
-                          if (empty($primary_key_choices)) {
-                              throw new \InvalidArgumentException(
-                                sprintf($this->trans('commands.common.questions.columns.table_index_invalid'),
-                                  $primary_key_choices)
-                              );
-                          }
 
-                          return $primary_key_choices;
-                      },
-                      false,
-                      null,
-                      $column_names
-                    );
 
-                    if (empty($index)) {
-                        break;
-                    }
 
-                }
-
+        // --indexes options
+        $indexes = $input->getOption('indexes');
+        if (!$indexes) {
+            // @see \Drupal\AppConsole\Command\Helper\InstallTrait::installIndex
+            $indexes = $this->installIndex($output, $dialog);
         }
+        $input->setOption('indexes', $indexes);
 
-        $input->setOption('index', $index_options);
-    }
+
+
+
+
     }
 
     /**

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -113,12 +113,8 @@ class GeneratorInstallCommand extends GeneratorCommand
         foreach ($columns as $item) {
             $column_names[] = $item['column_name'];
         }
-        // add null to the array
-        array_push($column_names, 'null');
 
         $column_names_string = implode(', ', $column_names);
-        // remove null from the string
-        $column_names_string = substr($column_names_string, 0, -6);
 
         // --primary key options
         $primary_key = $input->getOption('primary-key');
@@ -135,7 +131,9 @@ class GeneratorInstallCommand extends GeneratorCommand
                   $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.table_primary_key'),
                     $column_names_string, ':'),
                   function ($primary_key_choices) use ($column_names) {
-                      if (!in_array($primary_key_choices, $column_names)) {
+                      $primary_key_choices = $this->getStringUtils()
+                        ->camelCaseToCommaSeparated($primary_key_choices);
+                      if (empty($primary_key_choices)) {
                           throw new \InvalidArgumentException(
                             sprintf($this->trans('commands.common.questions.columns.table_primary_key_invalid'),
                               $primary_key_choices)
@@ -148,10 +146,10 @@ class GeneratorInstallCommand extends GeneratorCommand
                   null,
                   $column_names
                 );
-
-                $input->setOption('primary-key', $primary_key_options);
             }
         }
+
+        $input->setOption('primary-key', $primary_key_options);
     }
 
     /**

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -132,13 +132,13 @@ class GeneratorInstallCommand extends GeneratorCommand
               true
             )
             ) {
-                $primary_key_options = $dialog->askAndValidate(
+                $primary_key = $dialog->askAndValidate(
                   $output,
                   $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.table_primary_key'),
                     $column_names_string, ':'),
-                  function ($primary_key_choices) use ($column_names) {
+                  function ($primary_key) use ($column_names) {
                       $primary_key_choices = $this->getStringUtils()
-                        ->camelCaseToCommaSeparated($primary_key_choices);
+                        ->camelCaseToCommaSeparated($primary_key);
                       if (empty($primary_key_choices)) {
                           throw new \InvalidArgumentException(
                             sprintf($this->trans('commands.common.questions.columns.table_primary_key_invalid'),
@@ -154,7 +154,7 @@ class GeneratorInstallCommand extends GeneratorCommand
                 );
             }
         }
-        $input->setOption('primary-key', $primary_key_options);
+        $input->setOption('primary-key', $primary_key);
 
         // --indexes options
         $indexes = $input->getOption('indexes');

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -38,7 +38,9 @@ class GeneratorInstallCommand extends GeneratorCommand
           ->addOption('columns', '', InputOption::VALUE_OPTIONAL,
             $this->trans('commands.common.options.columns'))
           ->addOption('primary-key', '', InputOption::VALUE_OPTIONAL,
-            $this->trans('commands.common.options.primary-key'));
+            $this->trans('commands.common.options.primary-key'))
+          ->addOption('index', '', InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.common.options.index'));
     }
 
     /**
@@ -51,11 +53,12 @@ class GeneratorInstallCommand extends GeneratorCommand
         $table_description = $input->getOption('table-description');
         $columns = $input->getOption('columns');
         $primary_key = $input->getOption('primary-key');
+        $index = $input->getOption('index');
 
         $this
           ->getGenerator()
           ->generate($module, $table_name, $table_description, $columns,
-            $primary_key);
+            $primary_key, $index);
     }
 
     /**
@@ -150,6 +153,49 @@ class GeneratorInstallCommand extends GeneratorCommand
         }
 
         $input->setOption('primary-key', $primary_key_options);
+
+        // --index options
+        $index = $input->getOption('index');
+        if (!$index) {
+            if ($dialog->askConfirmation(
+              $output,
+              $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm_table_index'),
+                'yes', '?'),
+              true
+            )
+            ) {
+                while (true) {
+                    $index_options = $dialog->askAndValidate(
+                      $output,
+                      $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.table_index'),
+                        $column_names_string, ':'),
+                      function ($primary_key_choices) use ($column_names) {
+                          $primary_key_choices = $this->getStringUtils()
+                            ->camelCaseToCommaSeparated($primary_key_choices);
+                          if (empty($primary_key_choices)) {
+                              throw new \InvalidArgumentException(
+                                sprintf($this->trans('commands.common.questions.columns.table_index_invalid'),
+                                  $primary_key_choices)
+                              );
+                          }
+
+                          return $primary_key_choices;
+                      },
+                      false,
+                      null,
+                      $column_names
+                    );
+
+                    if (empty($index)) {
+                        break;
+                    }
+
+                }
+
+        }
+
+        $input->setOption('index', $index_options);
+    }
     }
 
     /**

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -31,6 +31,7 @@ class GeneratorInstallCommand extends GeneratorCommand
           ->setHelp($this->trans('commands.generate.column.help'))
           ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
           ->addOption('table-name', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.generate.column.options.table-name'))
+          ->addOption('table-description', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.generate.column.options.table-description'))
           ->addOption('columns', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.common.options.columns'))
         ;
     }
@@ -42,11 +43,12 @@ class GeneratorInstallCommand extends GeneratorCommand
     {
         $module = $input->getOption('module');
         $table_name = $input->getOption('table-name');
+        $table_description = $input->getOption('table-description');
         $columns = $input->getOption('columns');
 
         $this
           ->getGenerator()
-          ->generate($module, $table_name, $columns);
+          ->generate($module, $table_name, $table_description, $columns);
     }
 
     /**
@@ -75,6 +77,17 @@ class GeneratorInstallCommand extends GeneratorCommand
             );
         }
         $input->setOption('table-name', $table_name);
+
+        // --table-description option
+        $table_description = $input->getOption('table-description');
+        if (!$table_description) {
+            $table_description = $dialog->ask(
+              $output,
+              $dialog->getQuestion($this->trans('commands.generate.column.questions.table-description'), 'Hit enter to exclude'),
+              null
+            );
+        }
+        $input->setOption('table-description', $table_description);
 
         // --column options
         $columns = $input->getOption('columns');

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -3,7 +3,10 @@
  * @file
  * Contains Drupal\AppConsole\Command\GeneratorInstallCommand.
  *
- * Todo: Permit the creation of more than one table.
+ * Todo: Creation of more than one table.
+ * Todo: Incrementally adding a new column.
+ * Todo: Better validation for $primary_key. Needs to validate multivalued keys.
+ * Todo: Add hook_uninstall()
  */
 
 namespace Drupal\AppConsole\Command;
@@ -151,23 +154,16 @@ class GeneratorInstallCommand extends GeneratorCommand
                 );
             }
         }
-
         $input->setOption('primary-key', $primary_key_options);
-
-
-
 
         // --indexes options
         $indexes = $input->getOption('indexes');
         if (!$indexes) {
             // @see \Drupal\AppConsole\Command\Helper\InstallTrait::installIndex
-            $indexes = $this->installIndex($output, $dialog);
+            $indexes = $this->installIndex($output, $dialog,
+              $column_names_string);
         }
         $input->setOption('indexes', $indexes);
-
-
-
-
 
     }
 

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -2,6 +2,8 @@
 /**
  * @file
  * Contains Drupal\AppConsole\Command\GeneratorInstallCommand.
+ *
+ * Todo: Permit the creation of more than one table.
  */
 
 namespace Drupal\AppConsole\Command;
@@ -29,7 +31,7 @@ class GeneratorInstallCommand extends GeneratorCommand
           ->setHelp($this->trans('commands.generate.column.help'))
           ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
           ->addOption('table-name', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.generate.column.options.table-name'))
-          ->addOption('column_inputs', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.common.options.column_inputs'))
+          ->addOption('columns', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.common.options.columns'))
         ;
     }
 
@@ -39,11 +41,11 @@ class GeneratorInstallCommand extends GeneratorCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $module = $input->getOption('module');
-        $column_inputs = $input->getOption('column_inputs');
+        $columns = $input->getOption('columns');
 
         $this
           ->getGenerator()
-          ->generate($module, $column_inputs);
+          ->generate($module, $columns);
     }
 
     /**
@@ -73,13 +75,13 @@ class GeneratorInstallCommand extends GeneratorCommand
         }
         $input->setOption('table-name', $table_name);
 
-        // --column_inputs option
-        $inputs = $input->getOption('column_inputs');
+        // --column options
+        $inputs = $input->getOption('columns');
         if (!$inputs) {
             // @see \Drupal\AppConsole\Command\Helper\InstallTrait::installQuestion
             $inputs = $this->installQuestion($output, $dialog);
         }
-        $input->setOption('column_inputs', $inputs);
+        $input->setOption('columns', $inputs);
     }
 
     /**

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\AppConsole\Command\GeneratorInstallCommand.
+ */
+
+namespace Drupal\AppConsole\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\AppConsole\Command\Helper\ModuleTrait;
+use Drupal\AppConsole\Command\Helper\InstallTrait;
+use Drupal\AppConsole\Generator\InstallGenerator;
+use Drupal\AppConsole\Command\Helper\ConfirmationTrait;
+
+class GeneratorInstallCommand extends GeneratorCommand
+{
+
+    use ModuleTrait;
+    use InstallTrait;
+    use ConfirmationTrait;
+
+    protected function configure()
+    {
+        $this
+          ->setName('generate:install')
+          ->setDescription($this->trans('commands.generate.column.description'))
+          ->setHelp($this->trans('commands.generate.column.help'))
+          ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+          ->addOption('table-name', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.generate.column.options.table-name'))
+          ->addOption('column_inputs', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.common.options.column_inputs'))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $module = $input->getOption('module');
+        $column_inputs = $input->getOption('column_inputs');
+
+        $this
+          ->getGenerator()
+          ->generate($module, $column_inputs);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $dialog = $this->getDialogHelper();
+
+        // --module option
+        $module = $input->getOption('module');
+        if (!$module) {
+            // @see Drupal\AppConsole\Command\Helper\ModuleTrait::moduleQuestion
+            $module = $this->moduleQuestion($output, $dialog);
+        }
+        $input->setOption('module', $module);
+
+        // --table-name option
+        $default_table_name = $input->getOption('module');
+        $table_name = $input->getOption('table-name');
+        if (!$table_name) {
+            $table_name = $dialog->ask(
+              $output,
+              $dialog->getQuestion($this->trans('commands.generate.column.questions.table-name'), $default_table_name),
+              $default_table_name
+            );
+        }
+        $input->setOption('table-name', $table_name);
+
+        // --column_inputs option
+        $inputs = $input->getOption('column_inputs');
+        if (!$inputs) {
+            // @see \Drupal\AppConsole\Command\Helper\InstallTrait::installQuestion
+            $inputs = $this->installQuestion($output, $dialog);
+        }
+        $input->setOption('column_inputs', $inputs);
+    }
+
+    /**
+     * @return \Drupal\AppConsole\Generator\InstallGenerator.
+     */
+    protected function createGenerator()
+    {
+        return new InstallGenerator();
+    }
+}

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -87,6 +87,7 @@ class GeneratorInstallCommand extends GeneratorCommand
               null
             );
         }
+        $table_description = $this->getStringUtils()->anyCaseToUcFirst($table_description);
         $input->setOption('table-description', $table_description);
 
         // --column options

--- a/src/Command/GeneratorInstallCommand.php
+++ b/src/Command/GeneratorInstallCommand.php
@@ -41,11 +41,12 @@ class GeneratorInstallCommand extends GeneratorCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $module = $input->getOption('module');
+        $table_name = $input->getOption('table-name');
         $columns = $input->getOption('columns');
 
         $this
           ->getGenerator()
-          ->generate($module, $columns);
+          ->generate($module, $table_name, $columns);
     }
 
     /**
@@ -64,13 +65,13 @@ class GeneratorInstallCommand extends GeneratorCommand
         $input->setOption('module', $module);
 
         // --table-name option
-        $default_table_name = $input->getOption('module');
         $table_name = $input->getOption('table-name');
         if (!$table_name) {
+            $table_name = $this->getStringUtils()->camelCaseToMachineName($module);
             $table_name = $dialog->ask(
               $output,
-              $dialog->getQuestion($this->trans('commands.generate.column.questions.table-name'), $default_table_name),
-              $default_table_name
+              $dialog->getQuestion($this->trans('commands.generate.column.questions.table-name'), $table_name),
+              $table_name
             );
         }
         $input->setOption('table-name', $table_name);

--- a/src/Command/GeneratorPermissionCommand.php
+++ b/src/Command/GeneratorPermissionCommand.php
@@ -2,6 +2,8 @@
 /**
  * @file
  * Contains Drupal\AppConsole\Command\GeneratorPermissionCommand.
+ *
+ * TODO: Update routing.yml with permission(s).
  */
 
 namespace Drupal\AppConsole\Command;

--- a/src/Command/Helper/FormTrait.php
+++ b/src/Command/Helper/FormTrait.php
@@ -85,7 +85,7 @@ trait FormTrait
                 if (in_array($input_type, array('checkboxes', 'radios', 'select'))) {
                     $input_options = $dialog->ask(
                       $output,
-                      $dialog->getQuestion(' Input options separated by comma', '', ':'),
+                      $dialog->getQuestion(' Input options separated by commas', '', ':'),
                       null
                     );
                 }

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -2,6 +2,8 @@
 /**
  * @file
  * Contains Drupal\AppConsole\Command\Helper\InstallTrait.
+ *
+ * Todo: Validation for index. Needs to validate multivalued indexes.
  */
 
 namespace Drupal\AppConsole\Command\Helper;
@@ -66,6 +68,8 @@ trait InstallTrait
               '64',
               '128',
               '255',
+              '512',
+              '1024',
               '2048',
               null,
             ];
@@ -251,11 +255,13 @@ trait InstallTrait
     /**
      * @param OutputInterface $output
      * @param HelperInterface $dialog
+     * @param column_names_string
      * @return mixed
      */
     public function installIndex(
       OutputInterface $output,
-      HelperInterface $dialog
+      HelperInterface $dialog,
+      $column_names_string
     ) {
         if ($dialog->askConfirmation(
           $output,
@@ -264,17 +270,21 @@ trait InstallTrait
           true
         )
         ) {
+
             $indexes = [];
             while (true) {
                 // Column name
                 $index_name = $dialog->ask(
                   $output,
                   $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.index_name'),
-                    '', ':'),
+                    $column_names_string, ':'),
                   null
                 );
-                $index_name_key = $this->getStringUtils()->camelCaseToMachineName($index_name);
-                $index_name_value = $this->getStringUtils()->camelCaseToCommaSeparated($index_name);
+
+                $index_name_key = $this->getStringUtils()
+                  ->camelCaseToMachineName($index_name);
+                $index_name_value = $this->getStringUtils()
+                  ->camelCaseToCommaSeparated($index_name);
 
                 if (empty($index_name)) {
                     break;
@@ -292,89 +302,3 @@ trait InstallTrait
         return null;
     }
 }
-
-//                // Not null
-//                $column_not_null = $dialog->askAndValidate(
-//                  $output,
-//                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Hit enter to exclude', ':'),
-//                  function ($column_not_null_options) use ($column_true_false) {
-//                      if (!in_array($column_not_null_options, $column_true_false)) {
-//                          throw new \InvalidArgumentException(
-//                            sprintf($this->trans('commands.common.questions.columns.column_not_null_invalid'), $column_not_null_options)
-//                          );
-//                      }
-//
-//                      return $column_not_null_options;
-//                  },
-//                  false,
-//                  null,
-//                  $column_true_false
-//                );
-
-
-//                $input->setOption('table-name', $table_name);
-
-
-//                $index_options = $dialog->askAndValidate(
-//                  $output,
-//                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.table_index'),
-//                    $column_names_string, ':'),
-//                  function ($primary_key_choices) use ($column_names) {
-//                      $primary_key_choices = $this->getStringUtils()
-//                        ->camelCaseToCommaSeparated($primary_key_choices);
-//                      if (empty($primary_key_choices)) {
-//                          throw new \InvalidArgumentException(
-//                            sprintf($this->trans('commands.common.questions.columns.table_index_invalid'),
-//                              $primary_key_choices)
-//                          );
-//                      }
-//
-//                      return $primary_key_choices;
-//                  },
-//                  false,
-//                  null,
-//                  $column_names
-//                );
-//
-//                if (empty($index)) {
-//                    break;
-//                }
-
-//            }
-//
-//        }
-//
-//        $input->setOption('index', $index_options);
-
-//        }
-
-//    public function getColumns()
-//    {
-//        return $this->columns;
-//    }
-//
-//
-//    /**
-//     * @param OutputInterface $output
-//     * @param HelperInterface $dialog
-//     * @return mixed
-//     */
-//    public function installPrimaryKey(OutputInterface $output, HelperInterface $dialog)
-//    {
-//        if ($dialog->askConfirmation(
-//          $output,
-//          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm_primary_key'),
-//            'yes', '?'),
-//          true
-//        )
-//        ) {
-//
-////            $columns = $this->installQuestion($output, $dialog);
-//
-//
-////            var_dump($this->columns);
-//            var_dump('eric');
-//        }
-//    }
-//    }
-

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -20,7 +20,7 @@ trait InstallTrait
     {
         if ($dialog->askConfirmation(
           $output,
-          $dialog->getQuestion($this->trans('commands.common.questions.column_inputs.confirm'), 'yes', '?'),
+          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm'), 'yes', '?'),
           true
         )
         ) {
@@ -42,6 +42,7 @@ trait InstallTrait
               'normal',
             ];
             $column_length = [
+              '3',
               '4',
               '10',
               '11',
@@ -53,12 +54,12 @@ trait InstallTrait
               '2048',
             ];
 
-            $column_inputs = [];
+            $columns = [];
             while (true) {
                 // Column name
                 $column_name = $dialog->ask(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.column_inputs.column_name'), '', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_name'), '', ':'),
                   null
                 );
 
@@ -69,18 +70,17 @@ trait InstallTrait
                 // Column type input
                 $column_type = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.column_inputs.column_type'), 'varchar', ':'),
-                  function ($column_input) use ($column_types) {
-                      if (!in_array($column_input, $column_types)) {
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_type'), 'varchar', ':'),
+                  function ($column_options) use ($column_types) {
+                      if (!in_array($column_options, $column_types)) {
                           throw new \InvalidArgumentException(
-                            sprintf($this->trans('commands.common.questions.column_inputs.column_invalid'), $column_input)
+                            sprintf($this->trans('commands.common.questions.columns.column_invalid'), $column_options)
                           );
                       }
 
-                      return $column_input;
+                      return $column_options;
                   },
                   false,
-                  'varchar',
                   'varchar',
                   $column_types
                 );
@@ -88,18 +88,18 @@ trait InstallTrait
                 // Description for input
                 $column_description = $dialog->ask(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.column_inputs.column_description'), '', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_description'), '', ':'),
                   null
                 );
 
-                array_push($column_inputs, array(
+                array_push($columns, array(
                   'column_name' => $column_name,
                   'column_type' => $column_type,
                   'column_description' => $column_description,
                 ));
             }
 
-            return $column_inputs;
+            return $columns;
         }
         return null;
     }

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -37,13 +37,17 @@ trait InstallTrait
             $column_true_false = [
               'TRUE',
               'FALSE',
-              'None',
+//              'None',
+              '\'\'',
+              null,
             ];
             $column_default_choices = [
               '\'\'',
               '0',
               '1',
-              'None',
+//              'None',
+              '\'\'',
+              null,
             ];
             $column_size = [
               'tiny',
@@ -51,6 +55,7 @@ trait InstallTrait
               'medium',
               'big',
               'normal',
+              null,
             ];
             $column_length = [
               '3',
@@ -63,6 +68,7 @@ trait InstallTrait
               '128',
               '255',
               '2048',
+              null,
             ];
 
             $columns = [];
@@ -86,7 +92,7 @@ trait InstallTrait
                   function ($column_options) use ($column_types) {
                       if (!in_array($column_options, $column_types)) {
                           throw new \InvalidArgumentException(
-                            sprintf($this->trans('commands.common.questions.columns.column_invalid'), $column_options)
+                            sprintf($this->trans('commands.common.questions.columns.column_type_invalid'), $column_options)
                           );
                       }
 
@@ -97,10 +103,32 @@ trait InstallTrait
                     $column_types
                 );
 
+                // varchar gets length
+                $column_type_options = '';
+                if (in_array($column_type, array('varchar'))) {
+
+                    $column_type_options = $dialog->askAndValidate(
+                      $output,
+                      $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_length'), '255', ':'),
+                      function ($column_type_choices) use ($column_length) {
+                          if (!in_array($column_type_choices, $column_length)) {
+                              throw new \InvalidArgumentException(
+                                sprintf($this->trans('commands.common.questions.columns.column_length_invalid'), $column_type_choices)
+                              );
+                          }
+
+                          return $column_type_choices;
+                      },
+                      false,
+                      '255',
+                      $column_length
+                    );
+                }
+
                 // Unsigned
                 $column_unsigned = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_unsigned'), 'TRUE or FALSE. Type None to exclude', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_unsigned'), 'TRUE or FALSE. Hit enter to exclude', ':'),
                   function ($column_unsigned_options) use ($column_true_false) {
                       if (!in_array($column_unsigned_options, $column_true_false)) {
                           throw new \InvalidArgumentException(
@@ -111,14 +139,14 @@ trait InstallTrait
                       return $column_unsigned_options;
                   },
                   false,
-                  'TRUE',
+                  null,
                   $column_true_false
                 );
 
                 // Not null
                 $column_not_null = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Type None to exclude', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Hit enter to exclude', ':'),
                   function ($column_not_null_options) use ($column_true_false) {
                       if (!in_array($column_not_null_options, $column_true_false)) {
                           throw new \InvalidArgumentException(
@@ -129,15 +157,14 @@ trait InstallTrait
                       return $column_not_null_options;
                   },
                   false,
-                  'TRUE',
+                  null,
                   $column_true_false
                 );
 
                 // Default
                 $column_default = $dialog->askAndValidate(
                   $output,
-//                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_default'), '\'\'', ':'),
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_default'), '0, 1, or \'\'. Type None to exclude', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_default'), '0, 1, or \'\'. Hit enter to exclude', ':'),
                   function ($column_default_options) use ($column_default_choices) {
                       if (!in_array($column_default_options, $column_default_choices)) {
                           throw new \InvalidArgumentException(
@@ -148,28 +175,43 @@ trait InstallTrait
                       return $column_default_options;
                   },
                   false,
-                  '\'\'',
+                  '0',
                   $column_default_choices
                 );
 
+                // Size
+                $column_size = $dialog->askAndValidate(
+                  $output,
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_size'), 'tiny. Hit enter to exclude', ':'),
+                  function ($column_size_options) use ($column_size) {
+                      if (!in_array($column_size_options, $column_size)) {
+                          throw new \InvalidArgumentException(
+                            sprintf($this->trans('commands.common.questions.columns.column_size_invalid'), $column_size_options)
+                          );
+                      }
 
-//                'unsigned' => TRUE,
-//                'not null' => TRUE,
-//                'default' => 0,
+                      return $column_size_options;
+                  },
+                  false,
+                  'tiny',
+                  $column_size
+                );
 
-                // Column Description
+                // Description
                 $column_description = $dialog->ask(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_description'), '', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_description'), 'Hit enter to exclude', ':'),
                   null
                 );
 
                 array_push($columns, array(
                   'column_name' => $column_name,
                   'column_type' => $column_type,
+                  'column_type_options' => $column_type_options,
                   'column_unsigned' => $column_unsigned,
                   'column_not_null' => $column_not_null,
                   'column_default' => $column_default,
+                  'column_size' => $column_size,
                   'column_description' => $column_description,
                 ));
             }

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -11,6 +11,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait InstallTrait
 {
+//    /**
+//     * @var $columns
+//     */
+//    protected $columns;
+//
     /**
      * @param OutputInterface $output
      * @param HelperInterface $dialog
@@ -37,16 +42,12 @@ trait InstallTrait
             $column_true_false = [
               'TRUE',
               'FALSE',
-//              'None',
-              '\'\'',
               null,
             ];
             $column_default_choices = [
               '\'\'',
               '0',
               '1',
-//              'None',
-              '\'\'',
               null,
             ];
             $column_size_choices = [
@@ -110,14 +111,14 @@ trait InstallTrait
                     $column_type_options = $dialog->askAndValidate(
                       $output,
                       $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_length'), '255', ':'),
-                      function ($column_type_choices) use ($column_length) {
-                          if (!in_array($column_type_choices, $column_length)) {
+                      function ($column_length_choices) use ($column_length) {
+                          if (!in_array($column_length_choices, $column_length)) {
                               throw new \InvalidArgumentException(
-                                sprintf($this->trans('commands.common.questions.columns.column_length_invalid'), $column_type_choices)
+                                sprintf($this->trans('commands.common.questions.columns.column_length_invalid'), $column_length_choices)
                               );
                           }
 
-                          return $column_type_choices;
+                          return $column_length_choices;
                       },
                       false,
                       '255',
@@ -182,7 +183,7 @@ trait InstallTrait
                 // Size
                 $column_size = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_size'), 'tiny. Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_size'), 'tiny, small, medium, big, normal. Hit enter to exclude', ':'),
                   function ($column_size_options) use ($column_size_choices) {
                       if (!in_array($column_size_options, $column_size_choices)) {
                           throw new \InvalidArgumentException(
@@ -219,5 +220,34 @@ trait InstallTrait
             return $columns;
         }
         return null;
+    }
+
+    public function getColumns()
+    {
+        return $this->columns;
+    }
+
+
+    /**
+     * @param OutputInterface $output
+     * @param HelperInterface $dialog
+     * @return mixed
+     */
+    public function installPrimaryKey(OutputInterface $output, HelperInterface $dialog)
+    {
+        if ($dialog->askConfirmation(
+          $output,
+          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm_primary_key'),
+            'yes', '?'),
+          true
+        )
+        ) {
+
+//            $columns = $this->installQuestion($output, $dialog);
+
+
+//            var_dump($this->columns);
+            var_dump('eric');
+        }
     }
 }

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -49,7 +49,7 @@ trait InstallTrait
               '\'\'',
               null,
             ];
-            $column_size = [
+            $column_size_choices = [
               'tiny',
               'small',
               'medium',
@@ -88,7 +88,7 @@ trait InstallTrait
                 // Column type
                 $column_type = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_type'), 'varchar', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_type'), 'varchar', ':'),
                   function ($column_options) use ($column_types) {
                       if (!in_array($column_options, $column_types)) {
                           throw new \InvalidArgumentException(
@@ -109,7 +109,7 @@ trait InstallTrait
 
                     $column_type_options = $dialog->askAndValidate(
                       $output,
-                      $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_length'), '255', ':'),
+                      $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_length'), '255', ':'),
                       function ($column_type_choices) use ($column_length) {
                           if (!in_array($column_type_choices, $column_length)) {
                               throw new \InvalidArgumentException(
@@ -128,7 +128,7 @@ trait InstallTrait
                 // Unsigned
                 $column_unsigned = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_unsigned'), 'TRUE or FALSE. Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_unsigned'), 'TRUE or FALSE. Hit enter to exclude', ':'),
                   function ($column_unsigned_options) use ($column_true_false) {
                       if (!in_array($column_unsigned_options, $column_true_false)) {
                           throw new \InvalidArgumentException(
@@ -146,7 +146,7 @@ trait InstallTrait
                 // Not null
                 $column_not_null = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Hit enter to exclude', ':'),
                   function ($column_not_null_options) use ($column_true_false) {
                       if (!in_array($column_not_null_options, $column_true_false)) {
                           throw new \InvalidArgumentException(
@@ -164,7 +164,7 @@ trait InstallTrait
                 // Default
                 $column_default = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_default'), '0, 1, or \'\'. Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_default'), '0, 1, or \'\'. Hit enter to exclude', ':'),
                   function ($column_default_options) use ($column_default_choices) {
                       if (!in_array($column_default_options, $column_default_choices)) {
                           throw new \InvalidArgumentException(
@@ -175,16 +175,16 @@ trait InstallTrait
                       return $column_default_options;
                   },
                   false,
-                  '0',
+                  null,
                   $column_default_choices
                 );
 
                 // Size
                 $column_size = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_size'), 'tiny. Hit enter to exclude', ':'),
-                  function ($column_size_options) use ($column_size) {
-                      if (!in_array($column_size_options, $column_size)) {
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_size'), 'tiny. Hit enter to exclude', ':'),
+                  function ($column_size_options) use ($column_size_choices) {
+                      if (!in_array($column_size_options, $column_size_choices)) {
                           throw new \InvalidArgumentException(
                             sprintf($this->trans('commands.common.questions.columns.column_size_invalid'), $column_size_options)
                           );
@@ -193,14 +193,14 @@ trait InstallTrait
                       return $column_size_options;
                   },
                   false,
-                  'tiny',
-                  $column_size
+                  null,
+                  $column_size_choices
                 );
 
                 // Description
                 $column_description = $dialog->ask(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_description'), 'Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_description'), 'Hit enter to exclude', ':'),
                   null
                 );
 

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -62,6 +62,7 @@ trait InstallTrait
                   $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_name'), '', ':'),
                   null
                 );
+                $column_name = $this->getStringUtils()->camelCaseToMachineName($column_name);
 
                 if (empty($column_name)) {
                     break;

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\AppConsole\Command\Helper\InstallTrait.
+ */
+
+namespace Drupal\AppConsole\Command\Helper;
+
+use Symfony\Component\Console\Helper\HelperInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait InstallTrait
+{
+    /**
+     * @param OutputInterface $output
+     * @param HelperInterface $dialog
+     * @return mixed
+     */
+    public function installQuestion(OutputInterface $output, HelperInterface $dialog)
+    {
+        if ($dialog->askConfirmation(
+          $output,
+          $dialog->getQuestion($this->trans('commands.common.questions.column_inputs.confirm'), 'yes', '?'),
+          true
+        )
+        ) {
+            $column_types = [
+              'serial',
+              'int',
+              'float',
+              'numeric',
+              'varchar',
+              'char',
+              'text',
+              'blob',
+            ];
+            $column_size = [
+              'tiny',
+              'small',
+              'medium',
+              'big',
+              'normal',
+            ];
+            $column_length = [
+              '4',
+              '10',
+              '11',
+              '12',
+              '32',
+              '64',
+              '128',
+              '255',
+              '2048',
+            ];
+
+            $column_inputs = [];
+            while (true) {
+                // Column name
+                $column_name = $dialog->ask(
+                  $output,
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.column_inputs.column_name'), '', ':'),
+                  null
+                );
+
+                if (empty($column_name)) {
+                    break;
+                }
+
+                // Column type input
+                $column_type = $dialog->askAndValidate(
+                  $output,
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.column_inputs.column_type'), 'varchar', ':'),
+                  function ($column_input) use ($column_types) {
+                      if (!in_array($column_input, $column_types)) {
+                          throw new \InvalidArgumentException(
+                            sprintf($this->trans('commands.common.questions.column_inputs.column_invalid'), $column_input)
+                          );
+                      }
+
+                      return $column_input;
+                  },
+                  false,
+                  'varchar',
+                  'varchar',
+                  $column_types
+                );
+
+                // Description for input
+                $column_description = $dialog->ask(
+                  $output,
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.column_inputs.column_description'), '', ':'),
+                  null
+                );
+
+                array_push($column_inputs, array(
+                  'column_name' => $column_name,
+                  'column_type' => $column_type,
+                  'column_description' => $column_description,
+                ));
+            }
+
+            return $column_inputs;
+        }
+        return null;
+    }
+}

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -30,14 +30,14 @@ trait InstallTrait
         )
         ) {
             $column_types = [
-              'serial',
-              'int',
-              'float',
-              'numeric',
-              'varchar',
-              'char',
-              'text',
               'blob',
+              'char',
+              'float',
+              'int',
+              'numeric',
+              'serial',
+              'text',
+              'varchar',
             ];
             $column_true_false = [
               'TRUE',
@@ -89,7 +89,7 @@ trait InstallTrait
                 // Column type
                 $column_type = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_type'), 'varchar', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_type'), 'blob, char, float, int, numeric, serial, text, varchar', ':'),
                   function ($column_options) use ($column_types) {
                       if (!in_array($column_options, $column_types)) {
                           throw new \InvalidArgumentException(

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -11,21 +11,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait InstallTrait
 {
-//    /**
-//     * @var $columns
-//     */
-//    protected $columns;
-//
     /**
      * @param OutputInterface $output
      * @param HelperInterface $dialog
      * @return mixed
      */
-    public function installQuestion(OutputInterface $output, HelperInterface $dialog)
-    {
+    public function installQuestion(
+      OutputInterface $output,
+      HelperInterface $dialog
+    ) {
         if ($dialog->askConfirmation(
           $output,
-          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm'), 'yes', '?'),
+          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm'),
+            'yes', '?'),
           true
         )
         ) {
@@ -77,10 +75,12 @@ trait InstallTrait
                 // Column name
                 $column_name = $dialog->ask(
                   $output,
-                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_name'), '', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_name'),
+                    '', ':'),
                   null
                 );
-                $column_name = $this->getStringUtils()->camelCaseToMachineName($column_name);
+                $column_name = $this->getStringUtils()
+                  ->camelCaseToMachineName($column_name);
 
                 if (empty($column_name)) {
                     break;
@@ -89,11 +89,14 @@ trait InstallTrait
                 // Column type
                 $column_type = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_type'), 'blob, char, float, int, numeric, serial, text, varchar', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_type'),
+                    'blob, char, float, int, numeric, serial, text, varchar',
+                    ':'),
                   function ($column_options) use ($column_types) {
                       if (!in_array($column_options, $column_types)) {
                           throw new \InvalidArgumentException(
-                            sprintf($this->trans('commands.common.questions.columns.column_type_invalid'), $column_options)
+                            sprintf($this->trans('commands.common.questions.columns.column_type_invalid'),
+                              $column_options)
                           );
                       }
 
@@ -101,7 +104,7 @@ trait InstallTrait
                   },
                   false,
                   'varchar',
-                    $column_types
+                  $column_types
                 );
 
                 // varchar gets length
@@ -110,11 +113,14 @@ trait InstallTrait
 
                     $column_type_options = $dialog->askAndValidate(
                       $output,
-                      $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_length'), '255', ':'),
+                      $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_length'),
+                        '255', ':'),
                       function ($column_length_choices) use ($column_length) {
-                          if (!in_array($column_length_choices, $column_length)) {
+                          if (!in_array($column_length_choices, $column_length)
+                          ) {
                               throw new \InvalidArgumentException(
-                                sprintf($this->trans('commands.common.questions.columns.column_length_invalid'), $column_length_choices)
+                                sprintf($this->trans('commands.common.questions.columns.column_length_invalid'),
+                                  $column_length_choices)
                               );
                           }
 
@@ -129,11 +135,15 @@ trait InstallTrait
                 // Unsigned
                 $column_unsigned = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_unsigned'), 'TRUE or FALSE. Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_unsigned'),
+                    'TRUE or FALSE. Hit enter to exclude', ':'),
                   function ($column_unsigned_options) use ($column_true_false) {
-                      if (!in_array($column_unsigned_options, $column_true_false)) {
+                      if (!in_array($column_unsigned_options,
+                        $column_true_false)
+                      ) {
                           throw new \InvalidArgumentException(
-                            sprintf($this->trans('commands.common.questions.columns.column_unsigned_invalid'), $column_unsigned_options)
+                            sprintf($this->trans('commands.common.questions.columns.column_unsigned_invalid'),
+                              $column_unsigned_options)
                           );
                       }
 
@@ -147,11 +157,15 @@ trait InstallTrait
                 // Not null
                 $column_not_null = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_not_null'),
+                    'TRUE or FALSE. Hit enter to exclude', ':'),
                   function ($column_not_null_options) use ($column_true_false) {
-                      if (!in_array($column_not_null_options, $column_true_false)) {
+                      if (!in_array($column_not_null_options,
+                        $column_true_false)
+                      ) {
                           throw new \InvalidArgumentException(
-                            sprintf($this->trans('commands.common.questions.columns.column_not_null_invalid'), $column_not_null_options)
+                            sprintf($this->trans('commands.common.questions.columns.column_not_null_invalid'),
+                              $column_not_null_options)
                           );
                       }
 
@@ -165,11 +179,17 @@ trait InstallTrait
                 // Default
                 $column_default = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_default'), '0, 1, or \'\'. Hit enter to exclude', ':'),
-                  function ($column_default_options) use ($column_default_choices) {
-                      if (!in_array($column_default_options, $column_default_choices)) {
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_default'),
+                    '0, 1, or \'\'. Hit enter to exclude', ':'),
+                  function ($column_default_options) use (
+                    $column_default_choices
+                  ) {
+                      if (!in_array($column_default_options,
+                        $column_default_choices)
+                      ) {
                           throw new \InvalidArgumentException(
-                            sprintf($this->trans('commands.common.questions.columns.column_default_invalid'), $column_default_options)
+                            sprintf($this->trans('commands.common.questions.columns.column_default_invalid'),
+                              $column_default_options)
                           );
                       }
 
@@ -183,11 +203,15 @@ trait InstallTrait
                 // Size
                 $column_size = $dialog->askAndValidate(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_size'), 'tiny, small, medium, big, normal. Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_size'),
+                    'tiny, small, medium, big, normal. Hit enter to exclude',
+                    ':'),
                   function ($column_size_options) use ($column_size_choices) {
-                      if (!in_array($column_size_options, $column_size_choices)) {
+                      if (!in_array($column_size_options, $column_size_choices)
+                      ) {
                           throw new \InvalidArgumentException(
-                            sprintf($this->trans('commands.common.questions.columns.column_size_invalid'), $column_size_options)
+                            sprintf($this->trans('commands.common.questions.columns.column_size_invalid'),
+                              $column_size_options)
                           );
                       }
 
@@ -201,7 +225,8 @@ trait InstallTrait
                 // Description
                 $column_description = $dialog->ask(
                   $output,
-                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_description'), 'Hit enter to exclude', ':'),
+                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_description'),
+                    'Hit enter to exclude', ':'),
                   null
                 );
 
@@ -219,35 +244,137 @@ trait InstallTrait
 
             return $columns;
         }
+
         return null;
     }
-
-    public function getColumns()
-    {
-        return $this->columns;
-    }
-
 
     /**
      * @param OutputInterface $output
      * @param HelperInterface $dialog
      * @return mixed
      */
-    public function installPrimaryKey(OutputInterface $output, HelperInterface $dialog)
-    {
+    public function installIndex(
+      OutputInterface $output,
+      HelperInterface $dialog
+    ) {
         if ($dialog->askConfirmation(
           $output,
-          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm_primary_key'),
+          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm_index'),
             'yes', '?'),
           true
         )
         ) {
+            $indexes = [];
+            while (true) {
+                // Column name
+                $index_name = $dialog->ask(
+                  $output,
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.index_name'),
+                    '', ':'),
+                  null
+                );
+                $index_name_key = $this->getStringUtils()->camelCaseToMachineName($index_name);
+                $index_name_value = $this->getStringUtils()->camelCaseToCommaSeparated($index_name);
 
-//            $columns = $this->installQuestion($output, $dialog);
+                if (empty($index_name)) {
+                    break;
+                }
 
+                array_push($indexes, array(
+                  'index_name_key' => $index_name_key,
+                  'index_name_value' => $index_name_value,
+                ));
+            }
 
-//            var_dump($this->columns);
-            var_dump('eric');
+            return $indexes;
         }
+
+        return null;
     }
 }
+
+//                // Not null
+//                $column_not_null = $dialog->askAndValidate(
+//                  $output,
+//                  $dialog->getQuestion('    ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Hit enter to exclude', ':'),
+//                  function ($column_not_null_options) use ($column_true_false) {
+//                      if (!in_array($column_not_null_options, $column_true_false)) {
+//                          throw new \InvalidArgumentException(
+//                            sprintf($this->trans('commands.common.questions.columns.column_not_null_invalid'), $column_not_null_options)
+//                          );
+//                      }
+//
+//                      return $column_not_null_options;
+//                  },
+//                  false,
+//                  null,
+//                  $column_true_false
+//                );
+
+
+//                $input->setOption('table-name', $table_name);
+
+
+//                $index_options = $dialog->askAndValidate(
+//                  $output,
+//                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.table_index'),
+//                    $column_names_string, ':'),
+//                  function ($primary_key_choices) use ($column_names) {
+//                      $primary_key_choices = $this->getStringUtils()
+//                        ->camelCaseToCommaSeparated($primary_key_choices);
+//                      if (empty($primary_key_choices)) {
+//                          throw new \InvalidArgumentException(
+//                            sprintf($this->trans('commands.common.questions.columns.table_index_invalid'),
+//                              $primary_key_choices)
+//                          );
+//                      }
+//
+//                      return $primary_key_choices;
+//                  },
+//                  false,
+//                  null,
+//                  $column_names
+//                );
+//
+//                if (empty($index)) {
+//                    break;
+//                }
+
+//            }
+//
+//        }
+//
+//        $input->setOption('index', $index_options);
+
+//        }
+
+//    public function getColumns()
+//    {
+//        return $this->columns;
+//    }
+//
+//
+//    /**
+//     * @param OutputInterface $output
+//     * @param HelperInterface $dialog
+//     * @return mixed
+//     */
+//    public function installPrimaryKey(OutputInterface $output, HelperInterface $dialog)
+//    {
+//        if ($dialog->askConfirmation(
+//          $output,
+//          $dialog->getQuestion($this->trans('commands.common.questions.columns.confirm_primary_key'),
+//            'yes', '?'),
+//          true
+//        )
+//        ) {
+//
+////            $columns = $this->installQuestion($output, $dialog);
+//
+//
+////            var_dump($this->columns);
+//            var_dump('eric');
+//        }
+//    }
+//    }
+

--- a/src/Command/Helper/InstallTrait.php
+++ b/src/Command/Helper/InstallTrait.php
@@ -34,6 +34,17 @@ trait InstallTrait
               'text',
               'blob',
             ];
+            $column_true_false = [
+              'TRUE',
+              'FALSE',
+              'None',
+            ];
+            $column_default_choices = [
+              '\'\'',
+              '0',
+              '1',
+              'None',
+            ];
             $column_size = [
               'tiny',
               'small',
@@ -68,7 +79,7 @@ trait InstallTrait
                     break;
                 }
 
-                // Column type input
+                // Column type
                 $column_type = $dialog->askAndValidate(
                   $output,
                   $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_type'), 'varchar', ':'),
@@ -83,10 +94,70 @@ trait InstallTrait
                   },
                   false,
                   'varchar',
-                  $column_types
+                    $column_types
                 );
 
-                // Description for input
+                // Unsigned
+                $column_unsigned = $dialog->askAndValidate(
+                  $output,
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_unsigned'), 'TRUE or FALSE. Type None to exclude', ':'),
+                  function ($column_unsigned_options) use ($column_true_false) {
+                      if (!in_array($column_unsigned_options, $column_true_false)) {
+                          throw new \InvalidArgumentException(
+                            sprintf($this->trans('commands.common.questions.columns.column_unsigned_invalid'), $column_unsigned_options)
+                          );
+                      }
+
+                      return $column_unsigned_options;
+                  },
+                  false,
+                  'TRUE',
+                  $column_true_false
+                );
+
+                // Not null
+                $column_not_null = $dialog->askAndValidate(
+                  $output,
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_not_null'), 'TRUE or FALSE. Type None to exclude', ':'),
+                  function ($column_not_null_options) use ($column_true_false) {
+                      if (!in_array($column_not_null_options, $column_true_false)) {
+                          throw new \InvalidArgumentException(
+                            sprintf($this->trans('commands.common.questions.columns.column_not_null_invalid'), $column_not_null_options)
+                          );
+                      }
+
+                      return $column_not_null_options;
+                  },
+                  false,
+                  'TRUE',
+                  $column_true_false
+                );
+
+                // Default
+                $column_default = $dialog->askAndValidate(
+                  $output,
+//                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_default'), '\'\'', ':'),
+                  $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_default'), '0, 1, or \'\'. Type None to exclude', ':'),
+                  function ($column_default_options) use ($column_default_choices) {
+                      if (!in_array($column_default_options, $column_default_choices)) {
+                          throw new \InvalidArgumentException(
+                            sprintf($this->trans('commands.common.questions.columns.column_default_invalid'), $column_default_options)
+                          );
+                      }
+
+                      return $column_default_options;
+                  },
+                  false,
+                  '\'\'',
+                  $column_default_choices
+                );
+
+
+//                'unsigned' => TRUE,
+//                'not null' => TRUE,
+//                'default' => 0,
+
+                // Column Description
                 $column_description = $dialog->ask(
                   $output,
                   $dialog->getQuestion('  ' . $this->trans('commands.common.questions.columns.column_description'), '', ':'),
@@ -96,6 +167,9 @@ trait InstallTrait
                 array_push($columns, array(
                   'column_name' => $column_name,
                   'column_type' => $column_type,
+                  'column_unsigned' => $column_unsigned,
+                  'column_not_null' => $column_not_null,
+                  'column_default' => $column_default,
                   'column_description' => $column_description,
                 ));
             }

--- a/src/Command/Helper/PermissionTrait.php
+++ b/src/Command/Helper/PermissionTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Contains Drupal\AppConsole\Command\Helper\PermissionsTrait.
+ * Contains Drupal\AppConsole\Command\Helper\PermissionTrait.
  */
 
 namespace Drupal\AppConsole\Command\Helper;

--- a/src/Command/Helper/PermissionTrait.php
+++ b/src/Command/Helper/PermissionTrait.php
@@ -37,7 +37,7 @@ trait PermissionTrait
                     break;
                 }
                 $permission = $this->getStringUtils()->camelCaseToLowerCase($permission);
-                $permission_title = $this->getStringUtils()->camelCaseToUcFirst($permission);
+                $permission_title = $this->getStringUtils()->anyCaseToUcFirst($permission);
 
                 array_push($permissions, array(
                   'permission' => $permission,

--- a/src/Generator/InstallGenerator.php
+++ b/src/Generator/InstallGenerator.php
@@ -10,11 +10,13 @@ class InstallGenerator extends Generator
     /**
      * @param  $module
      * @param  $columns
+     * @param  $table_name
      */
-    public function generate($module, $columns)
+    public function generate($module, $table_name, $columns)
     {
         $parameters = array(
           'module_name' => $module,
+          'table_name' => $table_name,
           'columns' => $columns,
         );
 

--- a/src/Generator/InstallGenerator.php
+++ b/src/Generator/InstallGenerator.php
@@ -13,8 +13,9 @@ class InstallGenerator extends Generator
      * @param  $table_description
      * @param  $columns
      * @param  $primary_key
+     * @param  $index
      */
-    public function generate($module, $table_name, $table_description, $columns, $primary_key)
+    public function generate($module, $table_name, $table_description, $columns, $primary_key, $index)
     {
         $parameters = array(
           'module_name' => $module,
@@ -22,6 +23,7 @@ class InstallGenerator extends Generator
           'table_description' => $table_description,
           'columns' => $columns,
           'primary_key' => $primary_key,
+          'index' => $index,
         );
 
         $this->renderFile(

--- a/src/Generator/InstallGenerator.php
+++ b/src/Generator/InstallGenerator.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\AppConsole\Generator\InstallGenerator.
+ */
+namespace Drupal\AppConsole\Generator;
+
+class InstallGenerator extends Generator
+{
+    /**
+     * @param  $module
+     * @param  $column_name
+     * @param  $column_type
+     * @param  $column_description
+     */
+    public function generate($module, $column_name, $column_type, $column_description)
+    {
+        $parameters = array(
+          'module_name' => $module,
+          'column_name' => $column_name,
+          'column_type' => $column_type,
+          'column_description' => $column_description,
+        );
+
+        $this->renderFile(
+          'module/install.twig',
+          $this->getModulePath($module) . '/' . $module . '.install',
+          $parameters
+        );
+    }
+}

--- a/src/Generator/InstallGenerator.php
+++ b/src/Generator/InstallGenerator.php
@@ -13,9 +13,9 @@ class InstallGenerator extends Generator
      * @param  $table_description
      * @param  $columns
      * @param  $primary_key
-     * @param  $index
+     * @param  $indexes
      */
-    public function generate($module, $table_name, $table_description, $columns, $primary_key, $index)
+    public function generate($module, $table_name, $table_description, $columns, $primary_key, $indexes)
     {
         $parameters = array(
           'module_name' => $module,
@@ -23,7 +23,7 @@ class InstallGenerator extends Generator
           'table_description' => $table_description,
           'columns' => $columns,
           'primary_key' => $primary_key,
-          'index' => $index,
+          'indexes' => $indexes,
         );
 
         $this->renderFile(

--- a/src/Generator/InstallGenerator.php
+++ b/src/Generator/InstallGenerator.php
@@ -12,14 +12,16 @@ class InstallGenerator extends Generator
      * @param  $table_name
      * @param  $table_description
      * @param  $columns
+     * @param  $primary_key
      */
-    public function generate($module, $table_name, $table_description, $columns)
+    public function generate($module, $table_name, $table_description, $columns, $primary_key)
     {
         $parameters = array(
           'module_name' => $module,
           'table_name' => $table_name,
           'table_description' => $table_description,
           'columns' => $columns,
+          'primary_key' => $primary_key,
         );
 
         $this->renderFile(

--- a/src/Generator/InstallGenerator.php
+++ b/src/Generator/InstallGenerator.php
@@ -9,14 +9,16 @@ class InstallGenerator extends Generator
 {
     /**
      * @param  $module
-     * @param  $columns
      * @param  $table_name
+     * @param  $table_description
+     * @param  $columns
      */
-    public function generate($module, $table_name, $columns)
+    public function generate($module, $table_name, $table_description, $columns)
     {
         $parameters = array(
           'module_name' => $module,
           'table_name' => $table_name,
+          'table_description' => $table_description,
           'columns' => $columns,
         );
 

--- a/src/Generator/InstallGenerator.php
+++ b/src/Generator/InstallGenerator.php
@@ -9,17 +9,13 @@ class InstallGenerator extends Generator
 {
     /**
      * @param  $module
-     * @param  $column_name
-     * @param  $column_type
-     * @param  $column_description
+     * @param  $columns
      */
-    public function generate($module, $column_name, $column_type, $column_description)
+    public function generate($module, $columns)
     {
         $parameters = array(
           'module_name' => $module,
-          'column_name' => $column_name,
-          'column_type' => $column_type,
-          'column_description' => $column_description,
+          'columns' => $columns,
         );
 
         $this->renderFile(

--- a/src/Generator/PermissionGenerator.php
+++ b/src/Generator/PermissionGenerator.php
@@ -9,14 +9,14 @@ class PermissionGenerator extends Generator
 {
     /**
      * @param  $module
-     * @param  $permission
+     * @param  $permissions
      * @param  $permission_title
      */
-    public function generate($module, $permission, $permission_title)
+    public function generate($module, $permissions, $permission_title)
     {
         $parameters = array(
           'module_name' => $module,
-          'permissions' => $permission,
+          'permissions' => $permissions,
           'permission_title' => $permission_title,
         );
 

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -20,6 +20,8 @@ class StringUtils extends Helper
     const REGEX_CAMEL_CASE_UNDER = '/([a-z])([A-Z])/';
     // This REGEX captures spaces around words
     const REGEX_SPACES = '/\s\s+/';
+    // This REGEX captures spaces, and comma, and combinations with comma and space *, *
+    const REGEX_COMMAS_SPACES = '/[\s,]+/';
 
     /**
      * Replaces non alphanumeric characters with underscores
@@ -56,6 +58,16 @@ class StringUtils extends Helper
     public function camelCaseToUnderscore($camel_case)
     {
         return strtolower(preg_replace(self::REGEX_CAMEL_CASE_UNDER, '$1_$2', $camel_case));
+    }
+
+    /**
+     * Converts camel-case strings to comma separated format
+     * @param  String $camel_case User input
+     * @return String
+     */
+    public function camelCaseToCommaSeparated($camel_case)
+    {
+        return strtolower(preg_replace(self::REGEX_COMMAS_SPACES, ', ', $camel_case));
     }
 
     public function getName()

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -61,13 +61,14 @@ class StringUtils extends Helper
     }
 
     /**
-     * Converts camel-case strings to comma separated format
+     * Converts camel-case strings to comma separated format. Single quotes wrap each value
      * @param  String $camel_case User input
      * @return String
      */
     public function camelCaseToCommaSeparated($camel_case)
     {
-        return strtolower(preg_replace(self::REGEX_COMMAS_SPACES, ', ', $camel_case));
+        $camel_case_name = strtolower(preg_replace(self::REGEX_COMMAS_SPACES, '\', \'', $camel_case));
+        return $camel_case_name;
     }
 
     public function getName()

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -49,7 +49,7 @@ class StringUtils extends Helper
     }
 
     /**
-     *  Converts camel-case strings to under-score format
+     * Converts camel-case strings to under-score format
      * @param  String $camel_case User input
      * @return String
      */
@@ -69,23 +69,27 @@ class StringUtils extends Helper
     }
 
     /**
-     * Converts My Name to my name. For permissions
-     * @param  String $permission User input
+     * Converts string to lower case, single space, and trims string.
+     * @param  String $string User input
      * @return String
      */
-    public function camelCaseToLowerCase($permission)
+    public function camelCaseToLowerCase($string)
     {
-        return strtolower(preg_replace(self::REGEX_SPACES, ' ', $permission));
+        return strtolower(preg_replace(self::REGEX_SPACES, ' ', $string));
     }
 
     /**
-     * Convert the first character of upper case. For permissions
-     * @param  String $permission_title User input
+     * Converts the first character of string to Upper case and trims the string.
+     * @param  String $string User input
      * @return String
      */
-    public function camelCaseToUcFirst($permission_title)
+    public function anyCaseToUcFirst($string)
     {
-        return ucfirst(preg_replace(self::REGEX_SPACES, ' ', $permission_title));
+        $string = preg_replace(self::REGEX_SPACES, ' ', $string);
+        $string = strtolower($string);
+        $string = ucfirst($string);
+
+        return $string;
     }
 
 }

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -1,3 +1,48 @@
-{{ column_name }}
-{{ column_type }}
-{{ column_description }}
+<?php
+
+{% block file_docblock %}
+/**
+ * @file
+ * Install, update and uninstall functions for the {{module_name}} module.
+ */
+{% endblock %}
+
+{% block file_methods %}
+/**
+ * Implements hook_schema().
+ */
+function {{module_name}}_schema() {
+  $schema['{{module_name}}'] = array(
+    'description' => 'needs twig here.',
+{% if columns %}
+    'fields' => array(
+{% for column in columns %}
+      '{{ column.column_name }}' => array(
+        'description' => '{{ column.column_description }}',
+        'type' => '{{ column.column_type }}',
+      ),
+{% endfor %}
+    ),
+  );
+
+  return $schema;
+}
+{% endif %}
+{% endblock %}
+
+{#function forum_schema() {#}
+  {#$schema['forum'] = array(#}
+    {#'description' => 'Stores the relationship of nodes to forum terms.',#}
+    {#'fields' => array(#}
+      {#'nid' => array(#}
+        {#'type' => 'int',#}
+        {#'unsigned' => TRUE,#}
+        {#'not null' => TRUE,#}
+        {#'default' => 0,#}
+        {#'description' => 'The {node}.nid of the node.',#}
+      {#),#}
+  {#);#}
+
+
+
+

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -14,7 +14,7 @@
 function {{ module_name }}_schema() {
   $schema['{{ table_name }}'] = array(
 {% if table_description | length %}
-    'description' => '{{ table_description }}',
+    'description' => "{{ table_description }}",
 {% endif %}
 {% if columns %}
     'fields' => array(
@@ -37,7 +37,7 @@ function {{ module_name }}_schema() {
         'size' => '{{ column.column_size }}',
 {% endif %}
 {% if column.column_description | length %}
-        'description' => '{{ column.column_description }}',
+        'description' => "{{ column.column_description }}",
 {% endif %}
       ),
 {% endfor %}
@@ -45,6 +45,7 @@ function {{ module_name }}_schema() {
 {% if primary_key | length %}
 
     'primary key' => array('{{ primary_key }}'),
+{% endif %}
 {% if indexes %}
     'indexes' => array(
 {% for index in indexes %}
@@ -56,6 +57,5 @@ function {{ module_name }}_schema() {
 
   return $schema;
 }
-{% endif %}
 {% endif %}
 {% endblock %}

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -42,8 +42,8 @@ function {{ module_name }}_schema() {
       ),
 {% endfor %}
     ),
-{% if primary_key | length %}
 
+{% if primary_key | length %}
     'primary key' => array('{{ primary_key }}'),
 {% endif %}
 {% if indexes %}

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -18,8 +18,17 @@ function {{module_name}}_schema() {
     'fields' => array(
 {% for column in columns %}
       '{{ column.column_name }}' => array(
-        'description' => '{{ column.column_description }}',
         'type' => '{{ column.column_type }}',
+{% if column.column_unsigned != 'None' %}
+        'unsigned' => {{ column.column_unsigned }},
+{% endif %}
+{% if column.column_not_null != 'None' %}
+        'not null' => {{ column.column_not_null }},
+{% endif %}
+{% if column.column_default != 'None' %}
+        'default' => {{ column.column_default }},
+{% endif %}
+        'description' => '{{ column.column_description }}',
       ),
 {% endfor %}
     ),
@@ -44,5 +53,8 @@ function {{module_name}}_schema() {
   {#);#}
 
 
+{#'unsigned' => TRUE,#}
+{#'not null' => TRUE,#}
+{#'default' => 0,#}
 
 

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -47,8 +47,8 @@ function {{ module_name }}_schema() {
     'primary key' => array('{{ primary_key }}'),
   );
 
-
   return $schema;
 }
+{% endif %}
 {% endif %}
 {% endblock %}

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -11,24 +11,34 @@
 /**
  * Implements hook_schema().
  */
-function {{module_name}}_schema() {
-  $schema['{{table_name}}'] = array(
-    'description' => 'needs twig here.',
+function {{ module_name }}_schema() {
+  $schema['{{ table_name }}'] = array(
+{% if table_description | length %}
+    'description' => '{{ table_description }}',
+{% endif %}
 {% if columns %}
     'fields' => array(
 {% for column in columns %}
       '{{ column.column_name }}' => array(
         'type' => '{{ column.column_type }}',
-{% if column.column_unsigned != 'None' %}
+{% if column.column_type_options | length %}
+        'length' => '{{ column.column_type_options }}',
+{% endif %}
+{% if column.column_unsigned | length %}
         'unsigned' => {{ column.column_unsigned }},
 {% endif %}
-{% if column.column_not_null != 'None' %}
+{% if column.column_not_null | length %}
         'not null' => {{ column.column_not_null }},
 {% endif %}
-{% if column.column_default != 'None' %}
+{% if column.column_default | length %}
         'default' => {{ column.column_default }},
 {% endif %}
+{% if column.column_size | length %}
+        'size' => '{{ column.column_size }}',
+{% endif %}
+{% if column.column_description | length %}
         'description' => '{{ column.column_description }}',
+{% endif %}
       ),
 {% endfor %}
     ),
@@ -38,23 +48,3 @@ function {{module_name}}_schema() {
 }
 {% endif %}
 {% endblock %}
-
-{#function forum_schema() {#}
-  {#$schema['forum'] = array(#}
-    {#'description' => 'Stores the relationship of nodes to forum terms.',#}
-    {#'fields' => array(#}
-      {#'nid' => array(#}
-        {#'type' => 'int',#}
-        {#'unsigned' => TRUE,#}
-        {#'not null' => TRUE,#}
-        {#'default' => 0,#}
-        {#'description' => 'The {node}.nid of the node.',#}
-      {#),#}
-  {#);#}
-
-
-{#'unsigned' => TRUE,#}
-{#'not null' => TRUE,#}
-{#'default' => 0,#}
-
-

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -45,6 +45,7 @@ function {{ module_name }}_schema() {
 {% if primary_key | length %}
 
     'primary key' => array('{{ primary_key }}'),
+    {{ index }}
   );
 
   return $schema;

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -1,0 +1,3 @@
+{{ column_name }}
+{{ column_type }}
+{{ column_description }}

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -12,7 +12,7 @@
  * Implements hook_schema().
  */
 function {{module_name}}_schema() {
-  $schema['{{module_name}}'] = array(
+  $schema['{{table_name}}'] = array(
     'description' => 'needs twig here.',
 {% if columns %}
     'fields' => array(

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -42,7 +42,11 @@ function {{ module_name }}_schema() {
       ),
 {% endfor %}
     ),
+{% if primary_key | length %}
+
+    'primary key' => array('{{ primary_key }}'),
   );
+
 
   return $schema;
 }

--- a/templates/module/install.twig
+++ b/templates/module/install.twig
@@ -45,7 +45,13 @@ function {{ module_name }}_schema() {
 {% if primary_key | length %}
 
     'primary key' => array('{{ primary_key }}'),
-    {{ index }}
+{% if indexes %}
+    'indexes' => array(
+{% for index in indexes %}
+      '{{ index.index_name_key }}' => array('{{ index.index_name_value }}'),
+{% endfor %}
+    ),
+{% endif %}
   );
 
   return $schema;

--- a/templates/module/permission.yml.twig
+++ b/templates/module/permission.yml.twig
@@ -1,4 +1,4 @@
-{% if permissions|length %}
+{% if permissions %}
 {% for permission in permissions %}
 {{ permission.permission }}:
   title: '{{ permission.permission_title }}'

--- a/templates/module/permission.yml.twig
+++ b/templates/module/permission.yml.twig
@@ -4,6 +4,6 @@
   title: '{{ permission.permission_title }}'
 {% endfor %}
 {% else %}
-Access Content:
-  title: 'access content'
+access content:
+  title: 'Access content'
 {% endif %}


### PR DESCRIPTION
This PR creates a .install file for modules that require a custom table. I need to write a test for this new functionality. Other than that several things have occurred to me while developing this generator.

Module generators need to work incrementally. Let's say I need to add a new column in the custom table, or a new field in the form, or a new permission. I don't want to have to re-generate that file from scratch again. I just want to add my new thing to the existing file and proceed. 

Anyway, this gets the .install generator on its way.