### PR TITLE
Change type from drupal-module to project.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "drupal/console",
     "description": "Drupal Console",
     "keywords": ["Drupal", "Console", "Development"],
-    "type": "drupal-module",
+    "type": "project",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
The Console is no longer a Drupal module, so its type should be project.