### PR TITLE
Fix parameters order in generate() for rest plugin generation.

### DIFF
--- a/src/Generator/PluginRestResourceGenerator.php
+++ b/src/Generator/PluginRestResourceGenerator.php
@@ -15,9 +15,9 @@ class PluginRestResourceGenerator extends Generator
      * @param  $plugin_label
      * @param  $plugin_id
      * @param  $plugin_url
-     * @param  $states
+     * @param  $plugin_states
      */
-    public function generate($module, $class_name, $plugin_id, $plugin_label, $plugin_url, $plugin_states)
+    public function generate($module, $class_name, $plugin_label, $plugin_id, $plugin_url, $plugin_states)
     {
         $parameters = [
           'module_name' => $module,

--- a/templates/module/src/Plugin/Rest/Resource/rest.php.twig
+++ b/templates/module/src/Plugin/Rest/Resource/rest.php.twig
@@ -9,14 +9,12 @@ namespace Drupal\{{module_name}}\Plugin\rest\resource;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Core\Entity\EntityManagerInterface;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\rest\Plugin\ResourceBase;
 use Drupal\rest\ResourceResponse;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Psr\Log\LoggerInterface;
 {% endblock %}
 
@@ -33,13 +31,15 @@ use Psr\Log\LoggerInterface;
  * )
  */
 class {{ class_name }} extends ResourceBase {% endblock %}
+
 {% block class_variables %}
   /**
-   * A curent user instance.
+   * A current user instance.
    *
    * @var \Drupal\Core\Session\AccountProxyInterface
    */
   protected $currentUser;
+
 {% endblock %}
 
 {% block class_construct %}
@@ -56,6 +56,8 @@ class {{ class_name }} extends ResourceBase {% endblock %}
    *   The available serialization formats.
    * @param \Psr\Log\LoggerInterface $logger
    *   A logger instance.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   A current user instance.
    */
   public function __construct(
     array $configuration,
@@ -68,6 +70,7 @@ class {{ class_name }} extends ResourceBase {% endblock %}
 
     $this->currentUser = $current_user;
   }
+
 {% endblock %}
 
 {% block class_create %}
@@ -84,6 +87,7 @@ class {{ class_name }} extends ResourceBase {% endblock %}
       $container->get('current_user')
     );
   }
+
 {% endblock %}
 
 {% block class_methods %}
@@ -102,7 +106,7 @@ class {{ class_name }} extends ResourceBase {% endblock %}
     // You must to implement the logic of your REST Resource here.
     // Use current user after pass authentication to validate access.
     /*if(!$this->currentUser->hasPermission($permission)) {
-    throw new AccessDeniedHttpException();
+      throw new AccessDeniedHttpException();
     }*/
 
     $response->setContent('<html><body><h1>Implement REST State {{ state }}!</h1></body></html>');


### PR DESCRIPTION
At the moment a rest plugin is generated with incorrect id and label, the order of these parameters is wrong.