### PR TITLE
Update composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,25 +23,23 @@
     "require": {
         "php": ">=5.4.5",
         "composer/installers": "~1.0",
-        "symfony/config": "2.6.*",
-        "symfony/console": "2.6.*",
-        "symfony/dependency-injection": "2.6.*",
-        "symfony/debug": "2.6.*",
-        "symfony/event-dispatcher": "2.6.*",
-        "symfony/finder": "2.6.*",
-        "symfony/http-foundation": "2.6.*",
-        "symfony/translation": "2.6.*",
-        "symfony/yaml": "2.6.*",
-        "twig/twig": "1.16.*",
+        "symfony/config": "2.7.*",
+        "symfony/console": "2.7.*",
+        "symfony/dependency-injection": "2.7.*",
+        "symfony/debug": "2.7.*",
+        "symfony/event-dispatcher": "2.7.*",
+        "symfony/finder": "2.7.*",
+        "symfony/http-foundation": "2.7.*",
+        "symfony/translation": "2.7.*",
+        "symfony/yaml": "2.7.*",
+        "twig/twig": "1.18.*",
         "herrera-io/phar-update": "1.*",
-        "symfony/dom-crawler": "2.6.*"
+        "symfony/dom-crawler": "2.7.*"
     },
     "require-dev": {
         "drupal/coder": "~8.1",
-        "drupal/core": "8.0.0-beta9",
-        "phpunit/phpunit": "4.4.*"
+        "phpunit/phpunit": "4.6.*"
     },
-    "minimum-stability": "dev",
     "bin": ["bin/console"],
     "config": {
         "bin-dir": "bin/"


### PR DESCRIPTION
This updates all Symfony components, twig and phpunit to the same version we use in Drupal core (8.0.x-dev). https://packagist.org/packages/drupal/core