### PR TITLE
Set proper package type in composer.json

### DIFF
--- a/templates/module/composer.json.twig
+++ b/templates/module/composer.json.twig
@@ -1,6 +1,6 @@
 {
   "name": "drupal/{{ machine_name }}",
-  "type": "{{ type }}",
+  "type": "drupal-{{ type }}",
   "description": "{{ description }}",
   "keywords": ["Drupal"],
   "license": "GPL-2.0+",


### PR DESCRIPTION
The naming convention for composer package types is ``drupal-module``, ``drupal-theme``, ``drupal-profile``etc. 