### PR TITLE
Fix access operation in AccessControlHandler

### DIFF
--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -32,7 +32,7 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
       case 'view':
         return AccessResult::allowedIfHasPermission($account, 'view {{ entity_class }} entity');
 
-      case 'edit':
+      case 'update':
         return AccessResult::allowedIfHasPermission($account, 'edit {{ entity_class }} entity');
 
       case 'delete':


### PR DESCRIPTION
The operation is called "update" instead of "edit". Related docs from "EntityAccessControlHandler::checkAccess"

```
   * @param string $operation
   *   The entity operation. Usually one of 'view', 'update' or 'delete'.
```