### PR TITLE
Remove deprecated default_value key from entity_value

### DIFF
--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -155,10 +155,10 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
       ->setLabel(t('Name'))
       ->setDescription(t('The name of the {{ entity_class }} entity.'))
       ->setSettings(array(
-        'default_value' => '',
         'max_length' => 50,
         'text_processing' => 0,
       ))
+      ->setDefaultValue('')
       ->setDisplayOptions('view', array(
         'label' => 'above',
         'type' => 'string',


### PR DESCRIPTION
The [correct way](http://drupal.stackexchange.com/questions/162287/how-to-create-a-default-value-for-an-entity-base-field-in-drupal-8) to set a default value on an entity is to use `setDefaultValue()` and **not** to pass a `default_value` key in the base table defs.

See related [patch to examples module](https://www.drupal.org/node/2511182).

Nb. I think it is useful to keep this code (which sets a zero-length string as the default) in there as an example of how to provide a default.