### PR TITLE
Convert t() to $this->t()

### DIFF
--- a/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
+++ b/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
@@ -26,8 +26,8 @@ class {{ entity_class }}ListController extends EntityListBuilder {% endblock %}
    * {@inheritdoc}
    */
   public function buildHeader() {
-    $header['id'] = t('{{ entity_class }}ID');
-    $header['name'] = t('Name');
+    $header['id'] = $this->t('{{ entity_class }}ID');
+    $header['name'] = $this->t('Name');
     return $header + parent::buildHeader();
   }
 

--- a/templates/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-delete.php.twig
@@ -26,7 +26,7 @@ class {{ entity_class }}DeleteForm extends ContentEntityConfirmFormBase {% endbl
    * {@inheritdoc}
    */
   public function getQuestion() {
-    return t('Are you sure you want to delete entity %name?', array('%name' => $this->entity->label()));
+    return $this->t('Are you sure you want to delete entity %name?', array('%name' => $this->entity->label()));
   }
 
   /**
@@ -40,7 +40,7 @@ class {{ entity_class }}DeleteForm extends ContentEntityConfirmFormBase {% endbl
    * {@inheritdoc}
    */
   public function getConfirmText() {
-    return t('Delete');
+    return $this->t('Delete');
   }
 
   /**

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -31,7 +31,7 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
     $entity = $this->entity;
 
     $form['langcode'] = array(
-      '#title' => t('Language'),
+      '#title' => $this->t('Language'),
       '#type' => 'language_select',
       '#default_value' => $entity->getUntranslated()->language()->getId(),
       '#languages' => Language::STATE_ALL,

--- a/templates/module/src/Entity/entity-content-views-data.php.twig
+++ b/templates/module/src/Entity/entity-content-views-data.php.twig
@@ -27,8 +27,8 @@ class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViews
 
     $data['{{ entity_name }}']['table']['base'] = array(
       'field' => 'id',
-      'title' => t('{{ entity_class }}'),
-      'help' => t('The {{ entity_name }} entity ID.'),
+      'title' => $this->t('{{ entity_class }}'),
+      'help' => $this->t('The {{ entity_name }} entity ID.'),
     );
 
     return $data;


### PR DESCRIPTION
This PR updates templates generated classes that still used t().

I'm chatting with Tim Plunkett in IRC right now about https://github.com/hechoendrupal/DrupalConsole/blob/master/templates/module/module.twig

Which generates

```
/**
 * Implements hook_help().
 */
function dcdtest_help($route_name, RouteMatchInterface $route_match) {
  switch ($route_name) {
    // Main module help for the dcdtest module.
    case 'help.page.dcdtest':
      $output = '';
      $output .= '<h3>' . t('About') . '</h3>';
      $output .= '<p>' . t('My Awesome Module') . '</p>';
      return $output;

    default:
  }
}
```