### PR TITLE
Add human readable name

### DIFF
--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -179,10 +179,12 @@ commands:
         module: common.options.module
         entity-class: The entity class name
         entity-name: The name of the entity
+        label: The entity label
       questions:
         module: common.questions.module
         entity-class: Enter the entity class name
         entity-name: Enter the entity name
+        label: Enter the entity label
     form:
       description: Generate a new "%s"
       help: The <info>"%s"</info> command helps you generate a new "%s"

--- a/src/Command/GeneratorEntityCommand.php
+++ b/src/Command/GeneratorEntityCommand.php
@@ -84,7 +84,7 @@ abstract class GeneratorEntityCommand extends GeneratorCommand
 
         $this
           ->getGenerator()
-          ->generate($module, $entity_name, $entity_class, $entityType, $label);
+          ->generate($module, $entity_name, $entity_class, $label, $entityType);
     }
 
     /**

--- a/src/Command/GeneratorEntityCommand.php
+++ b/src/Command/GeneratorEntityCommand.php
@@ -64,7 +64,13 @@ abstract class GeneratorEntityCommand extends GeneratorCommand
               null,
               InputOption::VALUE_REQUIRED,
               $this->trans('commands.generate.entity.options.entity-name')
-          );
+          )
+          ->addOption(
+              'label',
+              null,
+              InputOption::VALUE_REQUIRED,
+              $this->trans('commands.generate.entity.options.label')
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -74,10 +80,11 @@ abstract class GeneratorEntityCommand extends GeneratorCommand
         $module = $input->getOption('module');
         $entity_class = $input->getOption('entity-class');
         $entity_name = $input->getOption('entity-name');
+        $label = $input->getOption('label');
 
         $this
           ->getGenerator()
-          ->generate($module, $entity_name, $entity_class, $entityType);
+          ->generate($module, $entity_name, $entity_class, $entityType, $label);
     }
 
     /**
@@ -129,8 +136,20 @@ abstract class GeneratorEntityCommand extends GeneratorCommand
                 null
             );
         }
-
         $input->setOption('entity-name', $entity_name);
+
+        $default_label = $utils->camelCaseToHuman($entity_class);
+
+        // --label option
+        $label = $input->getOption('label');
+        if (!$label) {
+            $label = $dialog->ask(
+                $output,
+                $dialog->getQuestion($this->trans('commands.generate.entity.questions.label'), $default_label),
+                $default_label
+            );
+        }
+        $input->setOption('label', $label);
     }
 
     protected function createGenerator()

--- a/src/Command/GeneratorPluginBlockCommand.php
+++ b/src/Command/GeneratorPluginBlockCommand.php
@@ -114,18 +114,20 @@ class GeneratorPluginBlockCommand extends GeneratorCommand
         }
         $input->setOption('class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --label option
         $label = $input->getOption('label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.block.options.label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.block.options.label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --plugin-id option
         $plugin_id = $input->getOption('plugin-id');

--- a/src/Command/GeneratorPluginFieldCommand.php
+++ b/src/Command/GeneratorPluginFieldCommand.php
@@ -194,6 +194,8 @@ class GeneratorPluginFieldCommand extends GeneratorCommand
         }
         $input->setOption('type-label', $label);
 
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
+
         // --type-plugin-id option
         $plugin_id = $input->getOption('type-plugin-id');
 
@@ -202,9 +204,9 @@ class GeneratorPluginFieldCommand extends GeneratorCommand
                 $output,
                 $dialog->getQuestion(
                     $this->trans('commands.generate.plugin.field.questions.type-plugin-id'),
-                    $machine_name
+                    $default_label
                 ),
-                $machine_name
+                $default_label
             );
         }
         $input->setOption('type-plugin-id', $plugin_id);
@@ -237,18 +239,20 @@ class GeneratorPluginFieldCommand extends GeneratorCommand
         }
         $input->setOption('widget-class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --widget-label option
         $label = $input->getOption('widget-label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.field.questions.widget-label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.field.questions.widget-label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('widget-label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --widget-plugin-id option
         $plugin_id = $input->getOption('widget-plugin-id');
@@ -279,18 +283,20 @@ class GeneratorPluginFieldCommand extends GeneratorCommand
         }
         $input->setOption('formatter-class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --formatter-label option
         $label = $input->getOption('formatter-label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.field.questions.formatter-label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.field.questions.formatter-label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('formatter-label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --formatter-plugin-id option
         $plugin_id = $input->getOption('formatter-plugin-id');

--- a/src/Command/GeneratorPluginFieldFormatterCommand.php
+++ b/src/Command/GeneratorPluginFieldFormatterCommand.php
@@ -104,18 +104,20 @@ class GeneratorPluginFieldFormatterCommand extends GeneratorCommand
         }
         $input->setOption('class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --plugin label option
         $label = $input->getOption('label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.fieldformatter.questions.label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.fieldformatter.questions.label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --name option
         $plugin_id = $input->getOption('plugin-id');

--- a/src/Command/GeneratorPluginFieldTypeCommand.php
+++ b/src/Command/GeneratorPluginFieldTypeCommand.php
@@ -118,18 +118,20 @@ class GeneratorPluginFieldTypeCommand extends GeneratorCommand
         }
         $input->setOption('class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --plugin label option
         $label = $input->getOption('label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.fieldtype.questions.label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.fieldtype.questions.label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --name option
         $plugin_id = $input->getOption('plugin-id');

--- a/src/Command/GeneratorPluginFieldWidgetCommand.php
+++ b/src/Command/GeneratorPluginFieldWidgetCommand.php
@@ -104,18 +104,20 @@ class GeneratorPluginFieldWidgetCommand extends GeneratorCommand
         }
         $input->setOption('class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --plugin label option
         $label = $input->getOption('label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.fieldwidget.questions.label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.fieldwidget.questions.label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --name option
         $plugin_id = $input->getOption('plugin-id');

--- a/src/Command/GeneratorPluginImageEffectCommand.php
+++ b/src/Command/GeneratorPluginImageEffectCommand.php
@@ -103,18 +103,20 @@ class GeneratorPluginImageEffectCommand extends GeneratorCommand
         }
         $input->setOption('class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --plugin label option
         $label = $input->getOption('label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.imageeffect.questions.label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.imageeffect.questions.label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --name option
         $plugin_id = $input->getOption('plugin-id');

--- a/src/Command/GeneratorPluginRestResourceCommand.php
+++ b/src/Command/GeneratorPluginRestResourceCommand.php
@@ -140,6 +140,8 @@ class GeneratorPluginRestResourceCommand extends GeneratorCommand
         }
         $input->setOption('plugin-id', $plugin_id);
 
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
+
         // --plugin-id option
         $plugin_label = $input->getOption('plugin-label');
         if (!$plugin_label) {
@@ -147,9 +149,9 @@ class GeneratorPluginRestResourceCommand extends GeneratorCommand
                 $output,
                 $dialog->getQuestion(
                     $this->trans('commands.generate.plugin.rest.resource.questions.plugin-label'),
-                    $machine_name
+                    $default_label
                 ),
-                $machine_name
+                $default_label
             );
         }
         $input->setOption('plugin-label', $plugin_label);

--- a/src/Command/GeneratorPluginRulesActionCommand.php
+++ b/src/Command/GeneratorPluginRulesActionCommand.php
@@ -116,18 +116,20 @@ class GeneratorPluginRulesActionCommand extends GeneratorCommand
         }
         $input->setOption('class-name', $class_name);
 
-        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
 
         // --label option
         $label = $input->getOption('label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.rulesaction.options.label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion($this->trans('commands.generate.plugin.rulesaction.options.label'), $default_label),
+                $default_label
             );
         }
         $input->setOption('label', $label);
+
+        $machine_name = $this->getStringUtils()->camelCaseToUnderscore($class_name);
 
         // --plugin-id option
         $plugin_id = $input->getOption('plugin-id');

--- a/src/Command/GeneratorPluginTypeAnnotationCommand.php
+++ b/src/Command/GeneratorPluginTypeAnnotationCommand.php
@@ -106,13 +106,18 @@ class GeneratorPluginTypeAnnotationCommand extends GeneratorCommand
         }
         $input->setOption('machine-name', $machine_name);
 
+        $default_label = $this->getStringUtils()->camelCaseToHuman($class_name);
+
         // --label option
         $label = $input->getOption('label');
         if (!$label) {
             $label = $dialog->ask(
                 $output,
-                $dialog->getQuestion($this->trans('commands.generate.plugin.type.annotation.options.label'), $machine_name),
-                $machine_name
+                $dialog->getQuestion(
+                    $this->trans('commands.generate.plugin.type.annotation.options.label'),
+                    $default_label
+                ),
+              $default_label
             );
         }
         $input->setOption('label', $label);

--- a/src/Generator/EntityConfigGenerator.php
+++ b/src/Generator/EntityConfigGenerator.php
@@ -15,13 +15,15 @@ class EntityConfigGenerator extends Generator
      * @param string $module       Module name
      * @param string $entity_name  Entity machine name
      * @param string $entity_class Entity class name
+     * @param string $label        Entity label
      */
-    public function generate($module, $entity_name, $entity_class)
+    public function generate($module, $entity_name, $entity_class, $label)
     {
         $parameters = [
           'module' => $module,
           'entity_name' => $entity_name,
           'entity_class' => $entity_class,
+          'label' => $label,
         ];
 
         $this->renderFile(

--- a/src/Generator/EntityConfigGenerator.php
+++ b/src/Generator/EntityConfigGenerator.php
@@ -25,7 +25,6 @@ class EntityConfigGenerator extends Generator
           'entity_class' => $entity_class,
           'label' => $label,
         ];
-
         $this->renderFile(
             'module/config/schema/entity.schema.yml.twig',
             $this->getModulePath($module).'/config/schema/'.$entity_name.'.schema.yml',

--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -15,13 +15,15 @@ class EntityContentGenerator extends Generator
      * @param string $module       Module name
      * @param string $entity_name  Entity machine name
      * @param string $entity_class Entity class name
+     * @param string $label        Entity label
      */
-    public function generate($module, $entity_name, $entity_class)
+    public function generate($module, $entity_name, $entity_class, $label)
     {
         $parameters = [
           'module' => $module,
           'entity_name' => $entity_name,
           'entity_class' => $entity_class,
+            'label' => $label,
         ];
 
         $this->renderFile(

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -64,6 +64,18 @@ class StringUtils extends Helper
         return strtolower(preg_replace(self::REGEX_CAMEL_CASE_UNDER, '$1_$2', $camel_case));
     }
 
+    /**
+     * Converts camel-case strings to human readable format.
+     *
+     * @param String $camel_case User input
+     *
+     * @return String
+     */
+    public function camelCaseToHuman($camel_case)
+    {
+        return ucfirst(strtolower(preg_replace(self::REGEX_CAMEL_CASE_UNDER, '$1 $2', $camel_case)));
+    }
+
     public function getName()
     {
         return 'stringUtils';

--- a/templates/module/config/schema/entity.schema.yml.twig
+++ b/templates/module/config/schema/entity.schema.yml.twig
@@ -1,6 +1,6 @@
 {{ module }}.{{ entity_name }}.*:
   type: config_entity
-  label: '{{ entity_class }} config'
+  label: '{{ label }} config'
   mapping:
     id:
       type: string

--- a/templates/module/entity-content-page.php.twig
+++ b/templates/module/entity-content-page.php.twig
@@ -4,7 +4,7 @@
 {{ entity_name }}.page.inc{% endblock %}
 {% block extra_info %}
  *
- * {{ entity_class }} page callback file for the {{ label }} entity.
+ * {{ entity_class }} page callback file for the {{ label }}.
 {% endblock %}
 
 {% block use_class %}

--- a/templates/module/entity-content-page.php.twig
+++ b/templates/module/entity-content-page.php.twig
@@ -4,7 +4,7 @@
 {{ entity_name }}.page.inc{% endblock %}
 {% block extra_info %}
  *
- * {{ entity_class }} page callback file for the {{ entity_name }} entity.
+ * {{ entity_class }} page callback file for the {{ label }} entity.
 {% endblock %}
 
 {% block use_class %}
@@ -13,7 +13,7 @@ use Drupal\Core\Render\Element;
 
 {% block file_methods %}
 /**
- * Prepares variables for {{ entity_name }} templates.
+ * Prepares variables for {{ label }} templates.
  *
  * Default template: {{ entity_name }}.html.twig.
  *

--- a/templates/module/links.action-entity-content.yml.twig
+++ b/templates/module/links.action-entity-content.yml.twig
@@ -1,6 +1,6 @@
 entity.{{ entity_name }}.add_form:
   route_name: entity.{{ entity_name }}.add_form
-  title: 'Add {{ entity_class }}'
+  title: 'Add {{ label }}'
   appears_on:
     - entity.{{ entity_name }}.collection
     - entity.{{ entity_name }}.canonical

--- a/templates/module/links.action-entity.yml.twig
+++ b/templates/module/links.action-entity.yml.twig
@@ -1,6 +1,6 @@
 entity.{{ entity_name }}.add_form:
   route_name: 'entity.{{ entity_name }}.add_form'
-  title: 'Add {{ entity_class }}'
+  title: 'Add {{ label }}'
   appears_on:
     - entity.{{ entity_name }}.collection
 

--- a/templates/module/links.menu-entity-config.yml.twig
+++ b/templates/module/links.menu-entity-config.yml.twig
@@ -1,7 +1,7 @@
-# {{ entity_class }} menu items definition
+# {{ label }} menu items definition
 entity.{{ entity_name }}.collection:
-  title: '{{ entity_class }}'
+  title: '{{ label }}'
   route_name: entity.{{ entity_name }}.collection
-  description: 'List {{ entity_class }}'
+  description: 'List {{ label }}'
   parent: system.admin_structure
 

--- a/templates/module/links.menu-entity-content.yml.twig
+++ b/templates/module/links.menu-entity-content.yml.twig
@@ -1,12 +1,12 @@
-# {{ entity_class }} menu items definition
+# {{ label }} menu items definition
 entity.{{ entity_name }}.collection:
-  title: '{{ entity_class }}: Listing'
+  title: '{{ label }} list'
   route_name: entity.{{ entity_name }}.collection
-  description: 'List {{ entity_class }}'
+  description: 'List {{ label }}'
 
 {{ entity_name }}.admin.structure.settings:
-  title: {{ entity_class }} Settings
-  description: 'Configure {{ entity_class }} entity'
+  title: {{ label }} settings
+  description: 'Configure {{ label }}'
   route_name: {{ entity_name }}.settings
   parent: system.admin_structure
 

--- a/templates/module/links.task-entity-content.yml.twig
+++ b/templates/module/links.task-entity-content.yml.twig
@@ -1,4 +1,4 @@
-# {{ entity_class }} routing definition
+# {{ label }} routing definition
 {{ entity_name }}.settings_tab:
   route_name: {{ entity_name }}.settings
   title: 'Settings'

--- a/templates/module/permissions-entity-content.yml.twig
+++ b/templates/module/permissions-entity-content.yml.twig
@@ -1,16 +1,16 @@
 
-view {{ entity_class }} entity:
-  title: 'View {{ entity_class }} entity'
-  description: 'Allow view my {{ entity_class }}'
+view {{ label|lower }}:
+  title: 'View {{ label }}'
+  description: 'Allow view my {{ label }}'
 
-edit {{ entity_class }} entity:
-  title: 'Edit {{ entity_class }} entity'
-  description: 'Allow edit my {{ entity_class }}'
+edit {{ label|lower }}:
+  title: 'Edit {{ label }}'
+  description: 'Allow edit my {{ label }}'
 
-delete {{ entity_class }} entity:
-  title: 'Delete {{ entity_class }} entity'
-  description: 'Allow delete my {{ entity_class }}'
+delete {{ label|lower }}:
+  title: 'Delete {{ label }}'
+  description: 'Allow delete my {{ label }}'
 
-administer {{ entity_class }} entity:
-  title: 'Adminster {{ entity_class }} entity'
-  description: 'Allow administer my {{ entity_class }}'
+administer {{ label|lower }}:
+  title: 'Adminster {{ label }}'
+  description: 'Allow administer my {{ label }}'

--- a/templates/module/routing-entity-content.yml.twig
+++ b/templates/module/routing-entity-content.yml.twig
@@ -44,7 +44,7 @@ entity.{{ entity_name }}.delete_form:
   path: 'admin/structure/{{ entity_name }}'
   defaults:
    _form: '\Drupal\{{ module }}\Entity\Form\{{ entity_class }}SettingsForm'
-   _title: '{{ labe }} settings'
+   _title: '{{ label }} settings'
   requirements:
     _permission: 'administer {{ label|lower }}'
 

--- a/templates/module/routing-entity-content.yml.twig
+++ b/templates/module/routing-entity-content.yml.twig
@@ -4,7 +4,7 @@ entity.{{ entity_name }}.canonical:
   path: '/admin/{{ entity_name }}/{{ '{'~entity_name~'}' }}'
   defaults:
     _entity_view: '{{ entity_name }}'
-    _title: '{{ entity_class }} Content'
+    _title: '{{ label }}'
   requirements:
     _entity_access: '{{ entity_name }}.view'
 
@@ -12,15 +12,15 @@ entity.{{ entity_name }}.collection:
   path: '/admin/{{ entity_name }}'
   defaults:
     _entity_list: '{{ entity_name }}'
-    _title: '{{ entity_class }} List'
+    _title: '{{ label }} list'
   requirements:
-    _permission: 'view {{ entity_class }} entity'
+    _permission: 'view {{ label|lower }}'
 
 entity.{{ entity_name }}.add_form:
   path: '/admin/{{ entity_name }}/add'
   defaults:
     _entity_form: {{ entity_name }}.add
-    _title: 'Add {{ entity_class }}'
+    _title: 'Add {{ label }}'
   requirements:
     _entity_create_access: '{{ entity_name }}'
 
@@ -28,7 +28,7 @@ entity.{{ entity_name }}.edit_form:
   path: '/admin/{{ entity_name }}/{{ '{'~entity_name~'}' }}/edit'
   defaults:
     _entity_form: {{ entity_name }}.edit
-    _title: 'Edit {{ entity_class }}'
+    _title: 'Edit {{ label }}'
   requirements:
     _entity_access: '{{ entity_name }}.edit'
 
@@ -36,7 +36,7 @@ entity.{{ entity_name }}.delete_form:
   path: '/admin/{{ entity_name }}/{{ '{'~entity_name~'}' }}/delete'
   defaults:
     _entity_form: {{ entity_name }}.delete
-    _title: 'Delete {{ entity_class }}'
+    _title: 'Delete {{ label }}'
   requirements:
     _entity_access: '{{ entity_name }}.delete'
 
@@ -44,7 +44,7 @@ entity.{{ entity_name }}.delete_form:
   path: 'admin/structure/{{ entity_name }}'
   defaults:
    _form: '\Drupal\{{ module }}\Entity\Form\{{ entity_class }}SettingsForm'
-   _title: '{{ entity_class }} Settings'
+   _title: '{{ labe }} settings'
   requirements:
-    _permission: 'administer {{ entity_class }} entity'
+    _permission: 'administer {{ label|lower }}'
 

--- a/templates/module/routing-entity.yml.twig
+++ b/templates/module/routing-entity.yml.twig
@@ -4,7 +4,7 @@ entity.{{ entity_name }}.collection:
   path: '/admin/config/system/{{ entity_name }}'
   defaults:
     _entity_list: '{{ entity_name }}'
-    _title: '{{ entity_class }} Configuration'
+    _title: '{{ label }}'
   requirements:
     _permission: 'administer site configuration'
 
@@ -12,7 +12,7 @@ entity.{{ entity_name }}.add_form:
   path: '/admin/config/system/{{ entity_name }}/add'
   defaults:
     _entity_form: '{{ entity_name }}.add'
-    _title: 'Add {{ entity_class }}'
+    _title: 'Add {{ label }}'
   requirements:
     _permission: 'administer site configuration'
 
@@ -20,7 +20,7 @@ entity.{{ entity_name }}.edit_form:
   path: '/admin/config/system/{{ entity_name }}/{{ '{'~entity_name~'}' }}'
   defaults:
     _entity_form: '{{ entity_name }}.edit'
-    _title: 'Edit {{ entity_class }}'
+    _title: 'Edit {{ label }}'
   requirements:
     _permission: 'administer site configuration'
 
@@ -28,7 +28,7 @@ entity.{{ entity_name }}.delete_form:
   path: '/admin/config/system/{{ entity_name }}/{{ '{'~entity_name~'}' }}/delete'
   defaults:
     _entity_form: '{{ entity_name }}.delete'
-    _title: 'Delete {{ entity_class }}'
+    _title: 'Delete {{ label }}'
   requirements:
     _permission: 'administer site configuration'
 

--- a/templates/module/src/Controller/entity-listbuilder.php.twig
+++ b/templates/module/src/Controller/entity-listbuilder.php.twig
@@ -15,7 +15,7 @@ use Drupal\Core\Entity\EntityInterface;
 
 {% block class_declaration %}
 /**
- * Provides a listing of {{ entity_class }}.
+ * Provides a listing of {{ label }}.
  */
 class {{ entity_class }}ListBuilder extends ConfigEntityListBuilder {% endblock %}
 {% block class_methods %}
@@ -23,7 +23,7 @@ class {{ entity_class }}ListBuilder extends ConfigEntityListBuilder {% endblock 
    * {@inheritdoc}
    */
   public function buildHeader() {
-    $header['label'] = $this->t('{{ entity_class }}');
+    $header['label'] = $this->t('{{ label }}');
     $header['id'] = $this->t('Machine name');
     return $header + parent::buildHeader();
   }

--- a/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
+++ b/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Provides a list controller for {{ label }} entity.
+ * Provides a list controller for {{ label }}.
  *
  * @ingroup {{ module }}
  */

--- a/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
+++ b/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Provides a list controller for {{ entity_class }} entity.
+ * Provides a list controller for {{ label }} entity.
  *
  * @ingroup {{ module }}
  */
@@ -26,7 +26,7 @@ class {{ entity_class }}ListController extends EntityListBuilder {% endblock %}
    * {@inheritdoc}
    */
   public function buildHeader() {
-    $header['id'] = $this->t('{{ entity_class }}ID');
+    $header['id'] = $this->t('{{ label }} ID');
     $header['name'] = $this->t('Name');
     return $header + parent::buildHeader();
   }

--- a/templates/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-delete.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Provides a form for deleting a {{ label }} entity.
+ * Provides a form for deleting a {{ label }}.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-delete.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Provides a form for deleting a {{ entity_class }} entity.
+ * Provides a form for deleting a {{ label }} entity.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Language\Language;
 
 {% block class_declaration %}
 /**
- * Form controller for the {{ label }} entity edit forms.
+ * Form controller for the {{ label }} edit forms.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Language\Language;
 
 {% block class_declaration %}
 /**
- * Form controller for the {{ entity_class }} entity edit forms.
+ * Form controller for the {{ label }} entity edit forms.
  *
  * @ingroup {{module}}
  */
@@ -58,12 +58,12 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
     $status = $entity->save();
 
     if ($status) {
-      drupal_set_message($this->t('Saved the %label {{ entity_class }}.', array(
+      drupal_set_message($this->t('Saved the %label {{ label }}.', array(
         '%label' => $entity->label(),
       )));
     }
     else {
-      drupal_set_message($this->t('The %label {{ entity_class }} was not saved.', array(
+      drupal_set_message($this->t('The %label {{ label }} was not saved.', array(
         '%label' => $entity->label(),
       )));
     }

--- a/templates/module/src/Entity/Form/entity-settings.php.twig
+++ b/templates/module/src/Entity/Form/entity-settings.php.twig
@@ -47,7 +47,7 @@ class {{ entity_class }}SettingsForm extends FormBase {% endblock %}
 
 
   /**
-   * Define the form used for {{ entity_class }}  settings.
+   * Define the form used for {{ label }}  settings.
    *
    * @param array $form
    *   An associative array containing the structure of the form.
@@ -58,7 +58,7 @@ class {{ entity_class }}SettingsForm extends FormBase {% endblock %}
    *   Form definition array.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['{{ entity_class }}_settings']['#markup'] = 'Settings form for {{ entity_class }}. Manage field settings here.';
+    $form['{{ entity_class }}_settings']['#markup'] = 'Settings form for {{ label }}. Manage field settings here.';
     return $form;
   }
 {% endblock %}

--- a/templates/module/src/Entity/entity-content-views-data.php.twig
+++ b/templates/module/src/Entity/entity-content-views-data.php.twig
@@ -15,7 +15,7 @@ use Drupal\views\EntityViewsDataInterface;
 
 {% block class_declaration %}
 /**
- * Provides the views data for the {{ label }} entity type.
+ * Provides the views data for the {{ label }} type.
  */
 class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViewsDataInterface {% endblock %}
 {% block class_methods %}
@@ -28,7 +28,7 @@ class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViews
     $data['{{ entity_name }}']['table']['base'] = array(
       'field' => 'id',
       'title' => $this->t('{{ label }}'),
-      'help' => $this->t('The {{ label }} entity ID.'),
+      'help' => $this->t('The {{ label }} ID.'),
     );
 
     return $data;

--- a/templates/module/src/Entity/entity-content-views-data.php.twig
+++ b/templates/module/src/Entity/entity-content-views-data.php.twig
@@ -15,7 +15,7 @@ use Drupal\views\EntityViewsDataInterface;
 
 {% block class_declaration %}
 /**
- * Provides the views data for the {{ entity_class }} entity type.
+ * Provides the views data for the {{ label }} entity type.
  */
 class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViewsDataInterface {% endblock %}
 {% block class_methods %}
@@ -27,8 +27,8 @@ class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViews
 
     $data['{{ entity_name }}']['table']['base'] = array(
       'field' => 'id',
-      'title' => $this->t('{{ entity_class }}'),
-      'help' => $this->t('The {{ entity_name }} entity ID.'),
+      'title' => $this->t('{{ label }}'),
+      'help' => $this->t('The {{ label }} entity ID.'),
     );
 
     return $data;

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -19,13 +19,13 @@ use Drupal\user\UserInterface;
 
 {% block class_declaration %}
 /**
- * Defines the {{ entity_class }} entity.
+ * Defines the {{ label }} entity.
  *
  * @ingroup {{ module }}
  *
  * @ContentEntityType(
  *   id = "{{ entity_name }}",
- *   label = @Translation("{{ entity_class }} entity"),
+ *   label = @Translation("{{ label }}"),
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\{{ module }}\Entity\Controller\{{ entity_class }}ListController",

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -19,7 +19,7 @@ use Drupal\user\UserInterface;
 
 {% block class_declaration %}
 /**
- * Defines the {{ label }} entity.
+ * Defines the {{ label }}.
  *
  * @ingroup {{ module }}
  *
@@ -116,17 +116,17 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
     $fields['id'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('ID'))
-      ->setDescription(t('The ID of the {{ entity_class }} entity.'))
+      ->setDescription(t('The ID of the {{ label }}.'))
       ->setReadOnly(TRUE);
 
     $fields['uuid'] = BaseFieldDefinition::create('uuid')
       ->setLabel(t('UUID'))
-      ->setDescription(t('The UUID of the {{ entity_class }} entity.'))
+      ->setDescription(t('The UUID of the {{ label }}.'))
       ->setReadOnly(TRUE);
 
     $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Authored by'))
-      ->setDescription(t('The user ID of the {{ entity_class }} entity author.'))
+      ->setDescription(t('The user ID of the {{ label }} author.'))
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'user')
       ->setSetting('handler', 'default')
@@ -152,7 +152,7 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
 
     $fields['name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Name'))
-      ->setDescription(t('The name of the {{ entity_class }} entity.'))
+      ->setDescription(t('The name of the {{ label }}.'))
       ->setSettings(array(
         'max_length' => 50,
         'text_processing' => 0,
@@ -172,7 +172,7 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
 
     $fields['langcode'] = BaseFieldDefinition::create('language')
       ->setLabel(t('Language code'))
-      ->setDescription(t('The language code of {{ entity_class }} entity.'));
+      ->setDescription(t('The language code of {{ label }}.'));
 
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))

--- a/templates/module/src/Entity/entity.php.twig
+++ b/templates/module/src/Entity/entity.php.twig
@@ -15,7 +15,7 @@ use Drupal\{{ module }}\{{ entity_class }}Interface;
 
 {% block class_declaration %}
 /**
- * Defines the {{ label }} entity.
+ * Defines the {{ label }}.
  *
  * @ConfigEntityType(
  *   id = "{{ entity_name }}",

--- a/templates/module/src/Entity/entity.php.twig
+++ b/templates/module/src/Entity/entity.php.twig
@@ -15,11 +15,11 @@ use Drupal\{{ module }}\{{ entity_class }}Interface;
 
 {% block class_declaration %}
 /**
- * Defines the {{ entity_class }} entity.
+ * Defines the {{ label }} entity.
  *
  * @ConfigEntityType(
  *   id = "{{ entity_name }}",
- *   label = @Translation("{{ entity_class }}"),
+ *   label = @Translation("{{ label }}"),
  *   handlers = {
  *     "list_builder" = "Drupal\{{ module }}\Controller\{{ entity_class }}ListBuilder",
  *     "form" = {
@@ -45,14 +45,14 @@ use Drupal\{{ module }}\{{ entity_class }}Interface;
 class {{ entity_class }} extends ConfigEntityBase implements {{ entity_class }}Interface {% endblock %}
 {% block class_methods %}
   /**
-   * The {{ entity_class }} ID.
+   * The {{ label }} ID.
    *
    * @var string
    */
   protected $id;
 
   /**
-   * The {{ entity_class }} label.
+   * The {{ label }} label.
    *
    * @var string
    */

--- a/templates/module/src/Form/entity-delete.php.twig
+++ b/templates/module/src/Form/entity-delete.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Builds the form to delete a {{ entity_class }}.
+ * Builds the form to delete a {{ label }}.
  */
 class {{ entity_class }}DeleteForm extends EntityConfirmFormBase {% endblock %}
 {% block class_methods %}

--- a/templates/module/src/Form/entity.php.twig
+++ b/templates/module/src/Form/entity.php.twig
@@ -34,7 +34,7 @@ class {{ entity_class }}Form extends EntityForm {% endblock %}
       '#title' => $this->t('Label'),
       '#maxlength' => 255,
       '#default_value' => ${{ entity_name | machine_name }}->label(),
-      '#description' => $this->t("Label for the {{ entity_class }}."),
+      '#description' => $this->t("Label for the {{ label }}."),
       '#required' => TRUE,
     );
 
@@ -60,12 +60,12 @@ class {{ entity_class }}Form extends EntityForm {% endblock %}
     $status = ${{ entity_name | machine_name }}->save();
 
     if ($status) {
-      drupal_set_message($this->t('Saved the %label {{ entity_class }}.', array(
+      drupal_set_message($this->t('Saved the %label {{ label }}.', array(
         '%label' => ${{ entity_name | machine_name }}->label(),
       )));
     }
     else {
-      drupal_set_message($this->t('The %label {{ entity_class }} was not saved.', array(
+      drupal_set_message($this->t('The %label {{ label }} was not saved.', array(
         '%label' => ${{ entity_name | machine_name }}->label(),
       )));
     }

--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -17,7 +17,7 @@ use Drupal\Core\Access\AccessResult;
 
 {% block class_declaration %}
 /**
- * Access controller for the {{ label }} entity.
+ * Access controller for the {{ label }}.
  *
  * @see \Drupal\{{module}}\Entity\{{ entity_class }}.
  */

--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -17,7 +17,7 @@ use Drupal\Core\Access\AccessResult;
 
 {% block class_declaration %}
 /**
- * Access controller for the {{ entity_class }} entity.
+ * Access controller for the {{ label }} entity.
  *
  * @see \Drupal\{{module}}\Entity\{{ entity_class }}.
  */
@@ -30,13 +30,13 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
 
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view {{ entity_class }} entity');
+        return AccessResult::allowedIfHasPermission($account, 'view {{ label|lower }}');
 
       case 'update':
-        return AccessResult::allowedIfHasPermission($account, 'edit {{ entity_class }} entity');
+        return AccessResult::allowedIfHasPermission($account, 'edit {{ label|lower }}');
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete {{ entity_class }} entity');
+        return AccessResult::allowedIfHasPermission($account, 'delete {{ label|lower }}');
     }
 
     return AccessResult::allowed();
@@ -46,6 +46,6 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
    * {@inheritdoc}
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
-    return AccessResult::allowedIfHasPermission($account, 'add {{ entity_class }} entity');
+    return AccessResult::allowedIfHasPermission($account, 'add {{ label|lower }}');
   }
 {% endblock %}

--- a/templates/module/src/interface-entity-content.php.twig
+++ b/templates/module/src/interface-entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\user\EntityOwnerInterface;
 
 {% block class_declaration %}
 /**
- * Provides an interface defining a {{ entity_class }} entity.
+ * Provides an interface defining a {{ label }} entity.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/interface-entity-content.php.twig
+++ b/templates/module/src/interface-entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\user\EntityOwnerInterface;
 
 {% block class_declaration %}
 /**
- * Provides an interface defining a {{ label }} entity.
+ * Provides an interface defining a {{ label }}.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/interface-entity.php.twig
+++ b/templates/module/src/interface-entity.php.twig
@@ -14,7 +14,7 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
 
 {% block class_declaration %}
 /**
- * Provides an interface defining a {{ entity_class }} entity.
+ * Provides an interface defining a {{ label }} entity.
  */
 interface {{ entity_class }}Interface extends ConfigEntityInterface {% endblock %}
 {% block class_methods %}

--- a/templates/module/src/interface-entity.php.twig
+++ b/templates/module/src/interface-entity.php.twig
@@ -14,7 +14,7 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
 
 {% block class_declaration %}
 /**
- * Provides an interface defining a {{ label }} entity.
+ * Provides an interface defining a {{ label }}.
  */
 interface {{ entity_class }}Interface extends ConfigEntityInterface {% endblock %}
 {% block class_methods %}

--- a/templates/module/templates/entity-html.twig
+++ b/templates/module/templates/entity-html.twig
@@ -3,7 +3,7 @@
  * @file {{ entity_name }}.html.twig
  * Default theme implementation to present {{ entity_class }} data.
  *
- * This template is used when viewing a {{ entity_name }} entity's page,
+ * This template is used when viewing a {{ label }} entity's page,
  *
  *
  * Available variables:

--- a/templates/module/templates/entity-html.twig
+++ b/templates/module/templates/entity-html.twig
@@ -1,9 +1,9 @@
 {{ '{#' }}
 /**
  * @file {{ entity_name }}.html.twig
- * Default theme implementation to present {{ entity_class }} data.
+ * Default theme implementation to present {{ label }} data.
  *
- * This template is used when viewing a {{ label }} entity's page,
+ * This template is used when viewing a {{ label }} page,
  *
  *
  * Available variables:


### PR DESCRIPTION
This PR adds a human readable name (--label) to content entity and config entity generators.
Adds a human readable formatter `StringUtils::camelCaseToHuman`.
Applies the HR label format to plugins.

Affected commands:
```
generate:entity:config
generate:entity:content
generate:plugin:block
generate:plugin:field
generate:plugin:fieldformatter
generate:plugin:fieldtype
generate:plugin:fieldwidget
generate:plugin:imageeffect
generate:plugin:rest:resource
generate:plugin:rulesaction
generate:plugin:type:annotation
```