### PR TITLE
[console] Compact php files in the phar archive

### DIFF
--- a/box.json
+++ b/box.json
@@ -18,6 +18,9 @@
             "in": "vendor"
         }
     ],
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Php"
+    ],
     "main": "bin/console",
     "output": "console.phar",
     "stub": true


### PR DESCRIPTION
This will decrease size of _console.phar_ by 40% approximately.