### PR TITLE
[generate:entity:config] Improve spelling and grammar where the new entity labels are used

### DIFF
--- a/templates/module/entity-content-page.php.twig
+++ b/templates/module/entity-content-page.php.twig
@@ -4,7 +4,7 @@
 {{ entity_name }}.page.inc{% endblock %}
 {% block extra_info %}
  *
- * {{ entity_class }} page callback file for the {{ label }}.
+ * Page callback for {{ label }} entities.
 {% endblock %}
 
 {% block use_class %}

--- a/templates/module/links.menu-entity-content.yml.twig
+++ b/templates/module/links.menu-entity-content.yml.twig
@@ -2,11 +2,11 @@
 entity.{{ entity_name }}.collection:
   title: '{{ label }} list'
   route_name: entity.{{ entity_name }}.collection
-  description: 'List {{ label }}'
+  description: 'List {{ label }} entities'
 
 {{ entity_name }}.admin.structure.settings:
   title: {{ label }} settings
-  description: 'Configure {{ label }}'
+  description: 'Configure {{ label }} entities'
   route_name: {{ entity_name }}.settings
   parent: system.admin_structure
 

--- a/templates/module/permissions-entity-content.yml.twig
+++ b/templates/module/permissions-entity-content.yml.twig
@@ -1,13 +1,15 @@
+add {{ label|lower }} entities:
+  title: 'Create new {{ label }} entities'
 
-view {{ label|lower }}:
-  title: 'View {{ label }} entities'
-
-edit {{ label|lower }}:
-  title: 'Edit {{ label }} entities'
-
-delete {{ label|lower }}:
-  title: 'Delete {{ label }} entities'
-
-administer {{ label|lower }}:
+administer {{ label|lower }} entities:
   title: 'Administer {{ label }} entities'
   description: 'Allow to access the administration form to configure {{ label }} entities.'
+
+delete {{ label|lower }} entities:
+  title: 'Delete {{ label }} entities'
+
+edit {{ label|lower }} entities:
+  title: 'Edit {{ label }} entities'
+
+view {{ label|lower }} entities:
+  title: 'View {{ label }} entities'

--- a/templates/module/permissions-entity-content.yml.twig
+++ b/templates/module/permissions-entity-content.yml.twig
@@ -1,16 +1,13 @@
 
 view {{ label|lower }}:
-  title: 'View {{ label }}'
-  description: 'Allow view my {{ label }}'
+  title: 'View {{ label }} entities'
 
 edit {{ label|lower }}:
-  title: 'Edit {{ label }}'
-  description: 'Allow edit my {{ label }}'
+  title: 'Edit {{ label }} entities'
 
 delete {{ label|lower }}:
-  title: 'Delete {{ label }}'
-  description: 'Allow delete my {{ label }}'
+  title: 'Delete {{ label }} entities'
 
 administer {{ label|lower }}:
-  title: 'Adminster {{ label }}'
-  description: 'Allow administer my {{ label }}'
+  title: 'Administer {{ label }} entities'
+  description: 'Allow to access the administration form to configure {{ label }} entities.'

--- a/templates/module/routing-entity-content.yml.twig
+++ b/templates/module/routing-entity-content.yml.twig
@@ -14,7 +14,7 @@ entity.{{ entity_name }}.collection:
     _entity_list: '{{ entity_name }}'
     _title: '{{ label }} list'
   requirements:
-    _permission: 'view {{ label|lower }}'
+    _permission: 'view {{ label|lower }} entities'
 
 entity.{{ entity_name }}.add_form:
   path: '/admin/{{ entity_name }}/add'
@@ -46,5 +46,5 @@ entity.{{ entity_name }}.delete_form:
    _form: '\Drupal\{{ module }}\Entity\Form\{{ entity_class }}SettingsForm'
    _title: '{{ label }} settings'
   requirements:
-    _permission: 'administer {{ label|lower }}'
+    _permission: 'administer {{ label|lower }} entities'
 

--- a/templates/module/src/Controller/entity-listbuilder.php.twig
+++ b/templates/module/src/Controller/entity-listbuilder.php.twig
@@ -15,7 +15,7 @@ use Drupal\Core\Entity\EntityInterface;
 
 {% block class_declaration %}
 /**
- * Provides a listing of {{ label }}.
+ * Provides a listing of {{ label }} entities.
  */
 class {{ entity_class }}ListBuilder extends ConfigEntityListBuilder {% endblock %}
 {% block class_methods %}

--- a/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
+++ b/templates/module/src/Entity/Controller/listcontroller-entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Provides a list controller for {{ label }}.
+ * Provides a list controller for the {{ label }} entity.
  *
  * @ingroup {{ module }}
  */

--- a/templates/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-delete.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Provides a form for deleting a {{ label }}.
+ * Provides a form for deleting {{ label }} entities.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Language\Language;
 
 {% block class_declaration %}
 /**
- * Form controller for the {{ label }} edit forms.
+ * Form controller for {{ label }} edit forms.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/Entity/Form/entity-settings.php.twig
+++ b/templates/module/src/Entity/Form/entity-settings.php.twig
@@ -47,7 +47,7 @@ class {{ entity_class }}SettingsForm extends FormBase {% endblock %}
 
 
   /**
-   * Define the form used for {{ label }}  settings.
+   * Defines the settings form for {{ label }} entities.
    *
    * @param array $form
    *   An associative array containing the structure of the form.
@@ -58,7 +58,7 @@ class {{ entity_class }}SettingsForm extends FormBase {% endblock %}
    *   Form definition array.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['{{ entity_class }}_settings']['#markup'] = 'Settings form for {{ label }}. Manage field settings here.';
+    $form['{{ entity_class }}_settings']['#markup'] = 'Settings form for {{ label }} entities. Manage field settings here.';
     return $form;
   }
 {% endblock %}

--- a/templates/module/src/Entity/entity-content-views-data.php.twig
+++ b/templates/module/src/Entity/entity-content-views-data.php.twig
@@ -15,7 +15,7 @@ use Drupal\views\EntityViewsDataInterface;
 
 {% block class_declaration %}
 /**
- * Provides the views data for the {{ label }} type.
+ * Provides Views data for {{ label }} entities.
  */
 class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViewsDataInterface {% endblock %}
 {% block class_methods %}

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -19,7 +19,7 @@ use Drupal\user\UserInterface;
 
 {% block class_declaration %}
 /**
- * Defines the {{ label }}.
+ * Defines the {{ label }} entity.
  *
  * @ingroup {{ module }}
  *
@@ -172,7 +172,7 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
 
     $fields['langcode'] = BaseFieldDefinition::create('language')
       ->setLabel(t('Language code'))
-      ->setDescription(t('The language code of {{ label }}.'));
+      ->setDescription(t('The language code for the {{ label }} entity.'));
 
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -116,17 +116,17 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
     $fields['id'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('ID'))
-      ->setDescription(t('The ID of the {{ label }}.'))
+      ->setDescription(t('The ID of the {{ label }} entity.'))
       ->setReadOnly(TRUE);
 
     $fields['uuid'] = BaseFieldDefinition::create('uuid')
       ->setLabel(t('UUID'))
-      ->setDescription(t('The UUID of the {{ label }}.'))
+      ->setDescription(t('The UUID of the {{ label }} entity.'))
       ->setReadOnly(TRUE);
 
     $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Authored by'))
-      ->setDescription(t('The user ID of the {{ label }} author.'))
+      ->setDescription(t('The user ID of author of the {{ label }} entity.'))
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'user')
       ->setSetting('handler', 'default')
@@ -152,7 +152,7 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
 
     $fields['name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Name'))
-      ->setDescription(t('The name of the {{ label }}.'))
+      ->setDescription(t('The name of the {{ label }} entity.'))
       ->setSettings(array(
         'max_length' => 50,
         'text_processing' => 0,

--- a/templates/module/src/Entity/entity.php.twig
+++ b/templates/module/src/Entity/entity.php.twig
@@ -15,7 +15,7 @@ use Drupal\{{ module }}\{{ entity_class }}Interface;
 
 {% block class_declaration %}
 /**
- * Defines the {{ label }}.
+ * Defines the {{ label }} entity.
  *
  * @ConfigEntityType(
  *   id = "{{ entity_name }}",

--- a/templates/module/src/Form/entity-delete.php.twig
+++ b/templates/module/src/Form/entity-delete.php.twig
@@ -16,7 +16,7 @@ use Drupal\Core\Url;
 
 {% block class_declaration %}
 /**
- * Builds the form to delete a {{ label }}.
+ * Builds the form to delete {{ label }} entities.
  */
 class {{ entity_class }}DeleteForm extends EntityConfirmFormBase {% endblock %}
 {% block class_methods %}

--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -17,7 +17,7 @@ use Drupal\Core\Access\AccessResult;
 
 {% block class_declaration %}
 /**
- * Access controller for the {{ label }}.
+ * Access controller for the {{ label }} entity.
  *
  * @see \Drupal\{{module}}\Entity\{{ entity_class }}.
  */
@@ -30,13 +30,13 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
 
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view {{ label|lower }}');
+        return AccessResult::allowedIfHasPermission($account, 'view {{ label|lower }} entities');
 
       case 'update':
-        return AccessResult::allowedIfHasPermission($account, 'edit {{ label|lower }}');
+        return AccessResult::allowedIfHasPermission($account, 'edit {{ label|lower }} entities');
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete {{ label|lower }}');
+        return AccessResult::allowedIfHasPermission($account, 'delete {{ label|lower }} entities');
     }
 
     return AccessResult::allowed();
@@ -46,6 +46,6 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
    * {@inheritdoc}
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
-    return AccessResult::allowedIfHasPermission($account, 'add {{ label|lower }}');
+    return AccessResult::allowedIfHasPermission($account, 'add {{ label|lower }} entities');
   }
 {% endblock %}

--- a/templates/module/src/interface-entity-content.php.twig
+++ b/templates/module/src/interface-entity-content.php.twig
@@ -16,7 +16,7 @@ use Drupal\user\EntityOwnerInterface;
 
 {% block class_declaration %}
 /**
- * Provides an interface defining a {{ label }}.
+ * Provides an interface for defining {{ label }} entities.
  *
  * @ingroup {{module}}
  */

--- a/templates/module/src/interface-entity.php.twig
+++ b/templates/module/src/interface-entity.php.twig
@@ -14,7 +14,7 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
 
 {% block class_declaration %}
 /**
- * Provides an interface defining a {{ label }}.
+ * Provides an interface for defining {{ label }} entities.
  */
 interface {{ entity_class }}Interface extends ConfigEntityInterface {% endblock %}
 {% block class_methods %}

--- a/templates/module/src/plugin-type-annotation-manager.php.twig
+++ b/templates/module/src/plugin-type-annotation-manager.php.twig
@@ -22,7 +22,7 @@ class {{ class_name }}Manager extends DefaultPluginManager {% endblock %}
 {% block class_methods %}
 
   /**
-   * Constructs a {{ label }} Manager object.
+   * Constructor for {{ class_name }}Manager objects.
    *
    * @param \Traversable $namespaces
    *   An object that implements \Traversable which contains the root paths

--- a/templates/module/templates/entity-html.twig
+++ b/templates/module/templates/entity-html.twig
@@ -3,7 +3,7 @@
  * @file {{ entity_name }}.html.twig
  * Default theme implementation to present {{ label }} data.
  *
- * This template is used when viewing a {{ label }} page,
+ * This template is used when viewing {{ label }} pages.
  *
  *
  * Available variables:


### PR DESCRIPTION
Since #743 went in the permissions for generated content entities now look a bit weird. If I create a "Book" entity type the permission titles now read:

* View book
* Edit book
* Delete book
* Adminster book

Because this is singular this is confusing. Which book am I allowed to edit? What if I want to give a role the permission to edit all books?

It would be better if we follow the pattern used for all permissions in core: display the plural form. Since we do not know how our entity is spelled in plural we can simply add the word "entities":

* View book entities
* Edit book entities
* Delete book entities
* Adminster book entities

In the future it might be interesting to ask the user for the plural form when generating entities, we might be able to use it elsewhere too. But for now this would do the trick.

When we are touching this it would also be good to fix the spelling errors (e.g. "adminster") and remove the descriptions, since they are not adding any additional information and have bad grammar.