### PR TITLE
Remove closing bracket from FieldFormatter template

### DIFF
--- a/templates/module/src/Plugin/Field/FieldFormatter/fieldformatter.php.twig
+++ b/templates/module/src/Plugin/Field/FieldFormatter/fieldformatter.php.twig
@@ -67,5 +67,4 @@ class {{ class_name }} extends FormatterBase {% endblock %}
 
     return $element;
   }
-}
 {% endblock %}


### PR DESCRIPTION
The closing bracket for the class is part of ``base/class.php.twig``.