### PR TITLE
[travis] migrate to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - phpunit
   - php box.phar build
   - php console.phar --version
-  - sudo mv console.phar /usr/local/bin/drupal
+  - mv console.phar /usr/local/bin/drupal
   - ~/.composer/vendor/bin/drush dl drupal-8.0.0-beta12
   - mv drupal-8.0.0-beta12 drupal8.dev
   - cd drupal8.dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,11 @@ script:
   - phpunit
   - php box.phar build
   - php console.phar --version
-  - mv console.phar /usr/local/bin/drupal
   - ~/.composer/vendor/bin/drush dl drupal-8.0.0-beta12
   - mv drupal-8.0.0-beta12 drupal8.dev
   - cd drupal8.dev
   - ~/.composer/vendor/bin/drush site-install standard --yes --account-name=root --account-pass=toor --db-url=sqlite:$PROJECT_DIR/drupal8.dev/sites/default/files/console.sqlite
-  - drupal chain --file=$PROJECT_DIR/config/dist/chain.yml
+  - php ../console.phar chain --file=$PROJECT_DIR/config/dist/chain.yml
   - ~/.composer/vendor/bin/phpcs --warning-severity=0 --standard=~/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml $PROJECT_DIR/drupal8.dev/modules/custom/example
 
 notifications:


### PR DESCRIPTION
After reading a message on a previous build 
>This job ran on our legacy infrastructure. 

https://travis-ci.org/hechoendrupal/DrupalConsole/jobs/75182133
![travis-containers](https://cloud.githubusercontent.com/assets/366275/9213723/4c6fe59a-405b-11e5-9ef3-ecd832b301ea.png)

I decided to read the provided documentation link [Migrating from legacy to container-based infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/) and implemente the recomendation on this PR.
