### PR TITLE
[console] Add tab autocomplete for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ php -r "readfile('http://drupalconsole.com/installer');" | php
 # For example: move console.phar and rename it, 'drupal':
 mv console.phar /usr/local/bin/drupal
 
+# You can enable autocomplete (only bash and zsh for the moment)
+drupal init
+
+# Add this line to your shell configuration file
+source "$HOME/.console/console.rc" 2>/dev/null
+
 # Show all available Drupal Console commands.
 drupal
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,23 @@ php -r "readfile('http://drupalconsole.com/installer');" | php
 # For example: move console.phar and rename it, 'drupal':
 mv console.phar /usr/local/bin/drupal
 
-# You can enable autocomplete (only bash and zsh for the moment)
-drupal init
-
-# Add this line to your shell configuration file
-source "$HOME/.console/console.rc" 2>/dev/null
-
 # Show all available Drupal Console commands.
 drupal
 
 # Generate a module.
 drupal generate:module
+```
+
+## Enabling Autocomplete
+```
+# You can enable autocomplete by executing
+drupal init
+
+# Bash or Zsh: Add this line to your shell configuration file
+source "$HOME/.console/console.rc" 2>/dev/null
+
+# Fish: Create a symbolic link
+ln -s ~/.console/drupal.fish ~/.config/fish/completions/drupal.fish
 ```
 
 ## Using Drupal Console

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "herrera-io/phar-update": "1.*",
         "symfony/dom-crawler": "2.7.*",
         "alchemy/zippy": "0.2.*@dev",
-        "kriswallsmith/buzz": ">=0.15"
+        "kriswallsmith/buzz": ">=0.15",
+        "stecman/symfony-console-completion": "^0.5.1"
     },
     "bin": ["bin/console"],
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "af21eb99f410f2e702fdd6e07e0d500b",
+    "hash": "773d5ac4e949f8028933c5ba6a5f8b2d",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -430,7 +430,8 @@
                 {
                     "name": "Kevin Herrera",
                     "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
+                    "homepage": "http://kevin.herrera.io/",
+                    "role": "Developer"
                 }
             ],
             "description": "A library for self-updating Phars.",
@@ -726,6 +727,51 @@
                 "validator"
             ],
             "time": "2015-01-04 21:18:15"
+        },
+        {
+            "name": "stecman/symfony-console-completion",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stecman/symfony-console-completion.git",
+                "reference": "1a9fc7ab4820cd1aabbdc584c6b25d221e7b6cb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stecman/symfony-console-completion/zipball/1a9fc7ab4820cd1aabbdc584c6b25d221e7b6cb5",
+                "reference": "1a9fc7ab4820cd1aabbdc584c6b25d221e7b6cb5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/console": "~2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stecman\\Component\\Symfony\\Console\\BashCompletion\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Holdaway",
+                    "email": "stephen@stecman.co.nz"
+                }
+            ],
+            "description": "Automatic BASH completion for Symfony Console Component based applications.",
+            "time": "2015-05-07 12:21:50"
         },
         {
             "name": "symfony/config",

--- a/composer.lock
+++ b/composer.lock
@@ -371,7 +371,8 @@
                 {
                     "name": "Kevin Herrera",
                     "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
+                    "homepage": "http://kevin.herrera.io/",
+                    "role": "Developer"
                 }
             ],
             "description": "A library for simplifying JSON linting and validation.",
@@ -543,7 +544,8 @@
             "authors": [
                 {
                     "name": "Kevin Herrera",
-                    "email": "me@kevingh.com"
+                    "email": "me@kevingh.com",
+                    "homepage": "http://www.kevingh.com/"
                 }
             ],
             "description": "A parsing and comparison library for semantic versioning.",

--- a/config/translations/en/application.yml
+++ b/config/translations/en/application.yml
@@ -20,10 +20,10 @@ console:
         learning:
             route: "In order to to create pages it is necessary to define routes for them.\nA route maps a URL path to a controller. It defines with what function\nor method will be called when a URL is accessed.\nIf the user accesses http://drupal8.dev/{{ route }}, the routing\nsystem will look for a route with that path. In this case it will find a\nmatch, and execute the _controller callback. In this case the callback is\ndefined as a classname\n(\"\\Drupal\\{{ module }}\\Controller\\{{ class_name }}\")\nand a method (\"{{ route.method }}\")."
         autocomplete: |
-                    To enable auto-complete on bash or zsh add this line to your shell configuration file:
+                    Bash or Zsh: Add this line to your shell configuration file:
                     <info>source "$HOME/.console/console.rc" 2>/dev/null</info>
 
-                    On Fish shell just link the .fish file to fish completions directory
+                    Fish: Create a symbolic link
                     <info>ln -s ~/.console/drupal.fish ~/.config/fish/completions/drupal.fish</info>
 
     errors:

--- a/config/translations/en/application.yml
+++ b/config/translations/en/application.yml
@@ -19,6 +19,7 @@ console:
             copied: 'Copied files'
         learning:
             route: "In order to to create pages it is necessary to define routes for them.\nA route maps a URL path to a controller. It defines with what function\nor method will be called when a URL is accessed.\nIf the user accesses http://drupal8.dev/{{ route }}, the routing\nsystem will look for a route with that path. In this case it will find a\nmatch, and execute the _controller callback. In this case the callback is\ndefined as a classname\n(\"\\Drupal\\{{ module }}\\Controller\\{{ class_name }}\")\nand a method (\"{{ route.method }}\")."
+        autocomplete: 'To enable auto-complete, add this line to your shell configuration file: <info>source "$HOME/.console/console.rc" 2>/dev/null</info>'
     errors:
         invalid-command: 'Command "%s" is not defined.'
     input:

--- a/config/translations/en/application.yml
+++ b/config/translations/en/application.yml
@@ -19,7 +19,13 @@ console:
             copied: 'Copied files'
         learning:
             route: "In order to to create pages it is necessary to define routes for them.\nA route maps a URL path to a controller. It defines with what function\nor method will be called when a URL is accessed.\nIf the user accesses http://drupal8.dev/{{ route }}, the routing\nsystem will look for a route with that path. In this case it will find a\nmatch, and execute the _controller callback. In this case the callback is\ndefined as a classname\n(\"\\Drupal\\{{ module }}\\Controller\\{{ class_name }}\")\nand a method (\"{{ route.method }}\")."
-        autocomplete: 'To enable auto-complete, add this line to your shell configuration file: <info>source "$HOME/.console/console.rc" 2>/dev/null</info>'
+        autocomplete: |
+                    To enable auto-complete on bash or zsh add this line to your shell configuration file:
+                    <info>source "$HOME/.console/console.rc" 2>/dev/null</info>
+
+                    On Fish shell just link the .fish file to fish completions directory
+                    <info>ln -s ~/.console/drupal.fish ~/.config/fish/completions/drupal.fish</info>
+
     errors:
         invalid-command: 'Command "%s" is not defined.'
     input:

--- a/src/Application.php
+++ b/src/Application.php
@@ -296,4 +296,17 @@ class Application extends BaseApplication
     {
         return $this->translator->trans($key);
     }
+
+    /**
+     * Gets the default commands that should always be available.
+     *
+     * @return Command[] An array of default Command instances
+     */
+    protected function getDefaultCommands()
+    {
+        $commands = parent::getDefaultCommands();
+        $commands[] = new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand();
+        return $commands;
+
+    }
 }

--- a/src/Command/CompleteCommand.php
+++ b/src/Command/CompleteCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\CompleteCommand.
+ */
+
+namespace Drupal\Console\Command;
+
+use Drupal\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CompleteCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('complete')
+            ->setDescription($this->trans('commands.complete.description'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(array_keys($this->getApplication()->all()));
+    }
+}

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -72,6 +72,7 @@ class InitCommand extends Command
         }
 
         $this->createAutocomplete();
+        $output->writeln($this->trans('application.console.messages.autocomplete'));
     }
 
     protected function createAutocomplete()

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -10,7 +10,7 @@ namespace Drupal\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\AppConsole\Generator\AutocompleteGenerator;
+use Drupal\Console\Generator\AutocompleteGenerator;
 use Symfony\Component\Process\ProcessBuilder;
 
 class InitCommand extends Command
@@ -78,9 +78,7 @@ class InitCommand extends Command
     protected function createAutocomplete()
     {
         $generator = new AutocompleteGenerator();
-        $generator->setSkeletonDirs($this->getSkeletonDirs());
-        $generator->setTranslator($this->translator);
-        $generator->setHelpers($this->getHelperSet());
+        $generator->setHelperSet($this->getHelperSet());
 
         $application = $this->getApplication();
         $config = $application->getConfig();
@@ -101,8 +99,8 @@ class InitCommand extends Command
     {
         $module = $this->getModule();
         if ($module != 'AppConsole') {
-            $drupalAutoLoad = $this->getHelperSet()->get('drupal-autoload');
-            $drupal_root = $drupalAutoLoad->getDrupalRoot();
+            $drupal = $this->getDrupalHelper();
+            $drupal_root = $drupal->getRoot();
             $skeletonDirs[] = $drupal_root.drupal_get_path('module', $module).'/templates';
         }
 

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -89,8 +89,8 @@ class InitCommand extends Command
         $process = $processBuilder->getProcess();
         $process->setCommandLine('echo $_');
         $process->run();
-        $fullPAthExecutable = explode('/', $process->getOutput());
-        $executable = end($fullPAthExecutable);
+        $fullPathExecutable = explode('/', $process->getOutput());
+        $executable = trim(end($fullPathExecutable));
         $process->stop();
 
         $generator->generate($userPath, $executable);

--- a/src/EventSubscriber/ShowCompletedMessageListener.php
+++ b/src/EventSubscriber/ShowCompletedMessageListener.php
@@ -44,7 +44,7 @@ class ShowCompletedMessageListener implements EventSubscriberInterface
             return;
         }
 
-        $completedMessageKey = 'application.console.messages.completed';
+        /*$completedMessageKey = 'application.console.messages.completed';
 
         if ($command instanceof GeneratorCommand) {
             $completedMessageKey = 'application.console.messages.generated.completed';
@@ -53,7 +53,7 @@ class ShowCompletedMessageListener implements EventSubscriberInterface
         $completedMessage = $translatorHelper->trans($completedMessageKey);
         if ($completedMessage != $completedMessageKey) {
             $messageHelper->showMessage($output, $completedMessage);
-        }
+        }*/
     }
 
     /**

--- a/src/EventSubscriber/ShowCompletedMessageListener.php
+++ b/src/EventSubscriber/ShowCompletedMessageListener.php
@@ -17,6 +17,7 @@ class ShowCompletedMessageListener implements EventSubscriberInterface
     private $skipCommands = [
         'self-update',
         'list',
+        '_completion'
     ];
 
     /**
@@ -44,7 +45,7 @@ class ShowCompletedMessageListener implements EventSubscriberInterface
             return;
         }
 
-        /*$completedMessageKey = 'application.console.messages.completed';
+        $completedMessageKey = 'application.console.messages.completed';
 
         if ($command instanceof GeneratorCommand) {
             $completedMessageKey = 'application.console.messages.generated.completed';
@@ -53,7 +54,7 @@ class ShowCompletedMessageListener implements EventSubscriberInterface
         $completedMessage = $translatorHelper->trans($completedMessageKey);
         if ($completedMessage != $completedMessageKey) {
             $messageHelper->showMessage($output, $completedMessage);
-        }*/
+        }
     }
 
     /**

--- a/src/Generator/AutocompleteGenerator.php
+++ b/src/Generator/AutocompleteGenerator.php
@@ -2,12 +2,10 @@
 
 /**
  * @file
- * Contains Drupal\AppConsole\Generator\AutocompleteGenerator.
+ * Contains Drupal\Console\Generator\AutocompleteGenerator.
  */
 
-namespace Drupal\AppConsole\Generator;
-
-use Drupal\AppConsole\Console\Application;
+namespace Drupal\Console\Generator;
 
 class AutocompleteGenerator extends Generator
 {
@@ -23,6 +21,12 @@ class AutocompleteGenerator extends Generator
         $this->renderFile(
             'autocomplete/console.rc.twig',
             $user_path.'console.rc',
+            $parameters
+        );
+
+        $this->renderFile(
+            'autocomplete/console.fish.twig',
+            $user_path.'drupal.fish',
             $parameters
         );
     }

--- a/src/Generator/AutocompleteGenerator.php
+++ b/src/Generator/AutocompleteGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\AppConsole\Generator\AutocompleteGenerator.
+ */
+
+namespace Drupal\AppConsole\Generator;
+
+use Drupal\AppConsole\Console\Application;
+
+class AutocompleteGenerator extends Generator
+{
+    /**
+     * @param  $executable
+     */
+    public function generate($user_path, $executable)
+    {
+        $parameters = array(
+          'executable' => $executable,
+        );
+
+        $this->renderFile(
+            'autocomplete/console.rc.twig',
+            $user_path.'console.rc',
+            $parameters
+        );
+    }
+}

--- a/templates/autocomplete/console.fish.twig
+++ b/templates/autocomplete/console.fish.twig
@@ -1,0 +1,7 @@
+# Drupal console autocompletion
+
+function __complete_drupal
+  drupal complete |  command awk '{ print $1 }'
+end
+
+complete -x -c drupal -a "(__complete_drupal)"

--- a/templates/autocomplete/console.rc.twig
+++ b/templates/autocomplete/console.rc.twig
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Enable auto-completion.
+
+if HOOK=$( {{ executable ~'_completion -g -p '~executable}} ); then
+  # See https://github.com/stecman/symfony-console-completion/#zero-config-use
+  eval $(echo "$HOOK")
+  echo "$HOOK" | source /dev/stdin
+  source <(echo "$HOOK") 2>/dev/null
+fi

--- a/templates/autocomplete/console.rc.twig
+++ b/templates/autocomplete/console.rc.twig
@@ -2,7 +2,7 @@
 
 # Enable auto-completion.
 
-if HOOK=$( {{ executable ~'_completion -g -p '~executable}} ); then
+if HOOK=$({{executable}} _completion -g -p {{executable}}); then
   # See https://github.com/stecman/symfony-console-completion/#zero-config-use
   eval $(echo "$HOOK")
   echo "$HOOK" | source /dev/stdin


### PR DESCRIPTION
This  PR autocomplete available commands with `<tab>` solves #679 

### How to use it:? 
```
# You can enable autocomplete by executing
drupal init

# Bash or Zsh: Add this line to your shell configuration file
source "$HOME/.console/console.rc" 2>/dev/null

# Fish: Create a symbolic link
ln -s ~/.console/drupal.fish ~/.config/fish/completions/drupal.fish
```
NOTE: if you already ran init command before, you can use --override option to override with the latest version from project. Make sure you save a backup copy of your file If you make changes.