### PR TITLE
Wrong handling of Entity::save() return value

### DIFF
--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -57,15 +57,17 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
     $entity = $this->entity;
     $status = $entity->save();
 
-    if ($status) {
-      drupal_set_message($this->t('Saved the %label {{ label }}.', array(
-        '%label' => $entity->label(),
-      )));
-    }
-    else {
-      drupal_set_message($this->t('The %label {{ label }} was not saved.', array(
-        '%label' => $entity->label(),
-      )));
+    switch ($status) {
+      case SAVED_NEW:
+        drupal_set_message($this->t('Created the %label {{ label }}.', [
+          '%label' => $entity->label(),
+        ]));
+        break;
+
+      default:
+        drupal_set_message($this->t('Saved the %label {{ label }}.', [
+          '%label' => $entity->label(),
+        ]));
     }
     $form_state->setRedirect('entity.{{ entity_name }}.edit_form', ['{{ entity_name }}' => $entity->id()]);
   }

--- a/templates/module/src/Form/entity.php.twig
+++ b/templates/module/src/Form/entity.php.twig
@@ -59,15 +59,17 @@ class {{ entity_class }}Form extends EntityForm {% endblock %}
     ${{ entity_name | machine_name }} = $this->entity;
     $status = ${{ entity_name | machine_name }}->save();
 
-    if ($status) {
-      drupal_set_message($this->t('Saved the %label {{ label }}.', array(
-        '%label' => ${{ entity_name | machine_name }}->label(),
-      )));
-    }
-    else {
-      drupal_set_message($this->t('The %label {{ label }} was not saved.', array(
-        '%label' => ${{ entity_name | machine_name }}->label(),
-      )));
+    switch ($status) {
+      case SAVED_NEW:
+        drupal_set_message($this->t('Created the %label {{ label }}.', [
+          '%label' => ${{ entity_name | machine_name }}->label(),
+        ]));
+        break;
+
+      default:
+        drupal_set_message($this->t('Saved the %label {{ label }}.', [
+          '%label' => ${{ entity_name | machine_name }}->label(),
+        ]));
     }
     $form_state->setRedirectUrl(${{ entity_name | machine_name }}->urlInfo('collection'));
   }


### PR DESCRIPTION
Currently the entity form code that is generated thinks that the return value of `Entity::save() ` is a boolean indicating success or failure, but this is not correct. This probably changed at some point in the past.

In current HEAD if a failure occurs during the saving of the entity an exception is thrown. Instead of a boolean, this method returns either `SAVED_NEW` or `SAVED_UPDATED`. We can use this information to provide a more fitting message.