### PR TITLE
Use {@inheritdoc}

### DIFF
--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -23,7 +23,7 @@ use Drupal\Core\Language\Language;
 class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
 {% block class_methods %}
   /**
-   * Overrides Drupal\Core\Entity\EntityFormController::buildForm().
+   * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     /* @var $entity \Drupal\{{module}}\Entity\{{ entity_class }} */
@@ -41,7 +41,7 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
   }
 
   /**
-   * Overrides \Drupal\Core\Entity\EntityFormController::submit().
+   * {@inheritdoc}
    */
   public function submit(array $form, FormStateInterface $form_state) {
     // Build the entity object from the submitted values.
@@ -51,7 +51,7 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
   }
 
   /**
-   * Overrides Drupal\Core\Entity\EntityFormController::save().
+   * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;


### PR DESCRIPTION
Current documentation standards suggest to use `{@inheritdoc}` when overriding parent methods.