### PR TITLE
Remove use statements from generated Interfaces. Fixes #829

### DIFF
--- a/templates/base/interface.php.twig
+++ b/templates/base/interface.php.twig
@@ -9,15 +9,6 @@
 
 {% block namespace_interface %}{% endblock %}
 
-{% block use_interface %}{% endblock %}
-{% block use_interface_services %}
-{% if services is defined %}
-{% for service in services %}
-use {{ service.interface }};
-{% endfor %}
-{% endif %}
-{% endblock %}
-
 {% block interface_declaration %}{% endblock -%}{
 
 {% block interface_methods %}{% endblock %}


### PR DESCRIPTION
Interfaces don't require use statements, even when type hinting specific classes. This also fixes an error in that {{service.interface}} is never defined and causes an error when drupal console tries to generate an interface.