### PR TITLE
Add --generate-doc option

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -25,6 +25,7 @@ use Drupal\AppConsole\EventSubscriber\ValidateDependenciesListener;
 use Drupal\AppConsole\EventSubscriber\DefaultValueEventListener;
 use Drupal\AppConsole\Command\Helper\NestedArrayHelper;
 use Drupal\AppConsole\Helper\TwigRendererHelper;
+use Drupal\AppConsole\EventSubscriber\ShowGenerateDocListener;
 
 set_time_limit(0);
 
@@ -61,7 +62,6 @@ $helpers = [
     'renderer' => new TwigRendererHelper(),
     'message' => new MessageHelper($translatorHelper),
     'chain' => new ChainCommandHelper(),
-//    'nested-array' => new NestedArrayHelper(),
 ];
 
 $application->addHelpers($helpers);
@@ -69,6 +69,7 @@ $application->addHelpers($helpers);
 $dispatcher = new EventDispatcher();
 $dispatcher->addSubscriber(new ValidateDependenciesListener());
 $dispatcher->addSubscriber(new ShowWelcomeMessageListener());
+$dispatcher->addSubscriber(new ShowGenerateDocListener());
 $dispatcher->addSubscriber(new DefaultValueEventListener());
 $dispatcher->addSubscriber(new ShowGeneratedFilesListener());
 $dispatcher->addSubscriber(new CallCommandListener());

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -87,6 +87,9 @@ class Application extends BaseApplication
         $this->getDefinition()->addOption(
             new InputOption('--generate-inline', '--gi', InputOption::VALUE_NONE, $this->trans('application.console.arguments.generate-inline'))
         );
+        $this->getDefinition()->addOption(
+            new InputOption('--generate-doc', '--gd', InputOption::VALUE_NONE, $this->trans('application.console.arguments.generate-doc'))
+        );
     }
 
     /**
@@ -141,6 +144,15 @@ class Application extends BaseApplication
         if ($this->isRunningOnDrupalInstance($drupal_root)) {
             $this->setup($env, $debug);
             $this->bootstrap();
+        }
+
+        if (true === $input->hasParameterOption(array('--generate-doc', '--gd'))) {
+            $command = $this->get($commandName);
+            $command->addOption(
+                'generate-doc',
+                '--gd',
+                InputOption::VALUE_NONE, $this->trans('application.console.arguments.generate-doc')
+            );
         }
 
         parent::doRun($input, $output);

--- a/src/EventSubscriber/ShowGenerateDocListener.php
+++ b/src/EventSubscriber/ShowGenerateDocListener.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\AppConsole\EventSubscriber\ShowGenerateDocListener.
+ */
+
+namespace Drupal\AppConsole\EventSubscriber;
+
+use Drupal\AppConsole\Command\Helper\TranslatorHelper;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class ShowGenerateDocListener
+ * @package Drupal\AppConsole\EventSubscriber
+ */
+class ShowGenerateDocListener implements EventSubscriberInterface
+{
+    private $skipCommands = [
+        'self-update',
+        'list',
+    ];
+
+    private $skipOptions = [
+        'generate-doc'
+    ];
+
+    private $skipArguments = [
+    ];
+
+    /**
+     * @param ConsoleCommandEvent $event
+     * @return void
+     */
+    public function showGenerateDoc(ConsoleCommandEvent $event)
+    {
+        /**
+         * @var \Drupal\AppConsole\Command\Command $command
+         */
+        $command = $event->getCommand();
+        /**
+         * @var \Drupal\AppConsole\Console\Application $command
+         */
+        $application = $command->getApplication();
+        /**
+         * @var \Drupal\AppConsole\Config $config
+         */
+        $config = $application->getConfig();
+
+        $input = $command->getDefinition();
+        $options = $input->getOptions();
+        $arguments = $input->getArguments();
+
+        if (isset($options['generate-doc']) && $options['generate-doc'] == 1) {
+            foreach ($this->skipOptions as $remove_option) {
+                unset($options[$remove_option]);
+            }
+
+            $parameters = [
+              'options' => $options,
+              'arguments' => $arguments,
+              'command' => $command->getName(),
+              'description' => $command->getDescription(),
+              'aliases' => $command->getAliases()
+            ];
+
+            $renderedDoc = $application->getHelperSet()->get('renderer')->render(
+                'base/generate-doc.md.twig',
+                $parameters
+            );
+
+            $output = $event->getOutput();
+            $output->writeln($renderedDoc);
+
+            $event->disableCommand();
+        }
+    }
+
+    /**
+     * @{@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [ConsoleEvents::COMMAND => 'showGenerateDoc'];
+    }
+}

--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -121,7 +121,7 @@ class EntityContentGenerator extends Generator
             $parameters
         );
 
-        $content = $this->getRenderer()->renderView(
+        $content = $this->getRenderer()->render(
             'module/src/Entity/entity-content.theme.php.twig',
             $parameters
         );

--- a/src/Generator/PermissionGenerator.php
+++ b/src/Generator/PermissionGenerator.php
@@ -27,7 +27,7 @@ class PermissionGenerator extends Generator
             FILE_APPEND
         );
 
-        $content = $this->getRenderer()->renderView(
+        $content = $this->getRenderer()->render(
             'module/permission-routing.yml.twig',
             $parameters
         );

--- a/src/Helper/TwigRendererHelper.php
+++ b/src/Helper/TwigRendererHelper.php
@@ -36,6 +36,15 @@ class TwigRendererHelper extends Helper
         $this->translator = $translator;
     }
 
+    public function getSkeletonDirs()
+    {
+        if (!$this->skeletonDirs) {
+            $this->skeletonDirs[] = __DIR__ . '/../../templates';
+        }
+
+        return $this->skeletonDirs;
+    }
+
     /**
      * @param string $template
      * @param array  $parameters
@@ -46,7 +55,7 @@ class TwigRendererHelper extends Helper
     {
         if (!$this->engine) {
             $this->engine = new \Twig_Environment(
-                new \Twig_Loader_Filesystem($this->skeletonDirs), [
+                new \Twig_Loader_Filesystem($this->getSkeletonDirs()), [
                 'debug' => true,
                 'cache' => false,
                 'strict_variables' => true,

--- a/templates/base/generate-doc.md.twig
+++ b/templates/base/generate-doc.md.twig
@@ -1,0 +1,25 @@
+# {{ command }}
+The **{{ command }}** command {{ description }}
+
+**Usage:**
+```
+$ drupal {{ command }} {% if arguments|length>0 %}[arguments] {% endif %}{% if options|length>0 %}[options] {% endif %}
+
+```
+
+{% if options|length>0 %}
+## Available options
+Option | Details
+-------|-------------
+{% for option in options %}
+--{{ option.name }} | {{ option.description }}
+{% endfor %}
+{% endif %}
+{% if arguments|length>0 %}
+## Available arguments
+Argument | Details
+---------|-------------
+{% for argument in arguments %}
+{{ argument.name }} | {{ argument.description }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This PR provides a new `--generate-doc` option to automate documentation generation.

![--generate-doc](https://cloud.githubusercontent.com/assets/366275/9844387/b0fd74f6-5a77-11e5-874b-e282723ab774.png)

The generated content is `markdown` format just to copy and paste into a file at the gitbook repository
https://github.com/hechoendrupal/drupal-console-book 