### PR TITLE
[generate:command] Updated the verification process of generated commands

### DIFF
--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -1008,6 +1008,13 @@ commands:
           executing-required-previous-updates: 'Executing required previous updates'
   user:
     login:
+      description: Returns a one time user login url.
+      options:
+        user-id: User ID.
+      messages:
+        url: One time login for @name: @url
+      errors:
+       invalid-user: Cannot load user entity (User ID: @uid).
       clear:
         attempts:
            description: Clear login failed attempts for an account.

--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -245,7 +245,7 @@ commands:
         module: common.options.module
         controller-title: 'Controller title'
         class-name: Command Class name
-        command: Command name
+        command: Command name (Must end with the word 'Commmand')
         container: Access the services container
       questions:
         module: common.questions.module

--- a/src/Command/GeneratorCommandCommand.php
+++ b/src/Command/GeneratorCommandCommand.php
@@ -103,7 +103,7 @@ class GeneratorCommandCommand extends GeneratorCommand
                 $output,
                 $dialog->getQuestion($this->trans('commands.generate.command.questions.class'), 'DefaultCommand'),
                 function ($class) {
-                    return $this->validateClassName($class);
+                    return $this->validateCommandName($class);
                 },
                 false,
                 'DefaultCommand',

--- a/src/Command/UserLoginCommand.php
+++ b/src/Command/UserLoginCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Console\Command\UserLoginCommand.
+ */
+
+namespace Drupal\Console\Command;
+
+use Drupal\Component\Utility\SafeMarkup;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\Console\Command\Command;
+use Drupal\user\Entity\User;
+
+/**
+ * Class UserLoginCommand.
+ *
+ * @package Drupal\Console
+ */
+class UserLoginCommand extends Command {
+
+  /**
+   * @var int Error code: no user can be loaded with the given user id.
+   */
+  const ERROR_INVALID_USER = 1;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this
+      ->setName('user:login')
+      ->setDescription($this->trans('commands.user.login.description'))
+      ->addArgument('user-id', InputArgument::OPTIONAL, $this->trans('commands.user.login.options.user-id'), 1);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    global $base_url;
+
+    $uid = $input->getArgument('user-id');
+
+    $user = User::load($uid);
+
+    if ($user) {
+      $url = $base_url . user_pass_reset_url($user);
+      $text = $this->trans('command.user.login.messages.url');
+      $text = SafeMarkup::format($text, ['@name' => $user->getUsername(), '@url' => $url]);
+      $output->writeln($text);
+      return 0;
+    }
+
+    $text = $this->trans('command.user.login.errors.invalid-user');
+    $text = SafeMarkup::format($text, ['@uid' => uid]);
+    $output->writeln($text);
+
+    return ERROR_INVALID_USER;
+  }
+}

--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -16,6 +16,7 @@ class Validators extends Helper implements HelperInterface
     private $caches = [];
 
     const REGEX_CLASS_NAME = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+$/';
+    const REGEX_COMMAND_CLASS_NAME = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+Command$/';
     const REGEX_MACHINE_NAME = '/^[a-z0-9_]+$/';
     // This REGEX remove spaces between words
     const REGEX_REMOVE_SPACES = '/[\\s+]/';
@@ -41,6 +42,27 @@ class Validators extends Helper implements HelperInterface
             throw new \InvalidArgumentException(
                 sprintf(
                     'Class name "%s" is invalid, it must starts with a letter or underscore, followed by any number of letters, numbers, or underscores.',
+                    $class_name
+                )
+            );
+        }
+    }
+
+    public function validateCommandName($class_name)
+    {
+        if (preg_match(self::REGEX_COMMAND_CLASS_NAME, $class_name)) {
+            return $class_name;
+        } else if (preg_match(self::REGEX_CLASS_NAME, $class_name)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Command name "%s" is invalid, it must end with the word \'Command\'',
+                    $class_name
+                )
+            );
+        } else {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Command name "%s" is invalid, it must starts with a letter or underscore, followed by any number of letters, numbers, or underscores and then with the word \'Command\'.',
                     $class_name
                 )
             );


### PR DESCRIPTION
### Motivation
New users that are unfamiliar with some of the conventions might be unaware that commands must end with the word Command and can get confused.

### Solution
[generate:command] command will throw an error if such a name is requested.