### PR TITLE
Use <root>/autoload.php

### DIFF
--- a/src/Helper/DrupalHelper.php
+++ b/src/Helper/DrupalHelper.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Helper\Helper;
  */
 class DrupalHelper extends Helper
 {
-    const DRUPAL_AUTOLOAD = 'core/vendor/autoload.php';
+    const DRUPAL_AUTOLOAD = 'autoload.php';
 
     const DRUPAL_SETTINGS = 'sites/default/settings.php';
 


### PR DESCRIPTION
Console does not work with https://github.com/drupal-composer/drupal-project properly. Looks like refactoring to DrupalHelper introduced the bug.

Here is the failing Travis CI test. https://travis-ci.org/drupal-composer/drupal-project/jobs/81138968