### PR TITLE
[generate:entity:bundle] Accept blank spaces in human readable name.

### DIFF
--- a/src/Command/ContainerAwareCommand.php
+++ b/src/Command/ContainerAwareCommand.php
@@ -397,6 +397,11 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
         return $this->getValidator()->validateClassName($class_name);
     }
 
+    public function validateBundleTitle($bundle_title)
+    {
+        return $this->getValidator()->validateBundleTitle($bundle_title);
+    }
+
     public function validateMachineName($machine_name)
     {
         $machine_name = $this->getValidator()->validateMachineName($machine_name);

--- a/src/Command/GenerateEntityBundleCommand.php
+++ b/src/Command/GenerateEntityBundleCommand.php
@@ -106,7 +106,7 @@ class GenerateEntityBundleCommand extends GeneratorCommand
                 $output,
                 $dialog->getQuestion($this->trans('commands.generate.entity.bundle.questions.bundle-title'), 'default'),
                 function ($bundle_title) {
-                    return $this->validateClassName($bundle_title);
+                    return $this->validateBundleTitle($bundle_title);
                 },
                 false,
                 'default',

--- a/src/Generator/EntityBundleGenerator.php
+++ b/src/Generator/EntityBundleGenerator.php
@@ -48,11 +48,11 @@ class EntityBundleGenerator extends Generator
         /**
          * Generate core.entity_view_mode.node.teaser.yml
          */
-        $this->renderFile(
+/*         $this->renderFile(
             'module/src/Entity/Bundle/core.entity_view_mode.node.teaser.yml.twig',
             $this->getSite()->getModulePath($module) . '/config/install/core.entity_view_mode.node.teaser.yml',
             $parameters
-        );
+        ); */
 
         /**
          * Generate field.field.node.{ bundle_name }.body.yml
@@ -66,11 +66,11 @@ class EntityBundleGenerator extends Generator
         /**
          * Generate field.storage.node.body.yml
          */
-        $this->renderFile(
+/*         $this->renderFile(
             'module/src/Entity/Bundle/field.storage.node.body.yml.twig',
             $this->getSite()->getModulePath($module) . '/config/install/field.storage.node.body.yml',
             $parameters
-        );
+        ); */
 
         /**
          * Generate node.type.{ bundle_name }.yml

--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -48,6 +48,15 @@ class Validators extends Helper implements HelperInterface
         }
     }
 
+    public function validateBundleTitle($bundle_title)
+    {
+        if (!empty($bundle_title)) {
+            return $bundle_title;
+        } else {
+            throw new \InvalidArgumentException(sprintf('Bundle title "%s" is invalid.', $bundle_title));
+        }
+    }
+
     public function validateCommandName($class_name)
     {
         if (preg_match(self::REGEX_COMMAND_CLASS_NAME, $class_name)) {


### PR DESCRIPTION
#922 

The installation of my test module failed with the error message: "Unable to install My Test Module, core.entity_view_mode.node.teaser, field.storage.node.body already exist in active configuration."

I had to comment out the generation of both YML files in src/Generator/EntityBundleGenerator.php .

