### PR TITLE
[console] Entity access control handler no longer has a $langcode parameter

### DIFF
--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -26,7 +26,7 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
   /**
    * {@inheritdoc}
    */
-  protected function checkAccess(EntityInterface $entity, $operation, $langcode, AccountInterface $account) {
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
 
     switch ($operation) {
       case 'view':


### PR DESCRIPTION
See https://www.drupal.org/node/2581447 , this results in an error when generating entities.