### PR TITLE
[theme:download] Increase curl timeout to 10 seconds

### DIFF
--- a/src/Command/ThemeDownloadCommand.php
+++ b/src/Command/ThemeDownloadCommand.php
@@ -30,6 +30,7 @@ class ThemeDownloadCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $client = new Curl();
+        $client->setTimeout(10);
         $browser = new Browser($client);
 
         $theme = $input->getArgument('theme');


### PR DESCRIPTION
I was trying to download the zircon theme and was always getting timeout errors.  [Zircon](https://www.drupal.org/project/zircon) is about 2.66 Mb in size, which might not be an common occurrence.  Setting 10 seconds as the timeout was enough for me to be able to download it.

A couple of comments:
* Not sure if this is the proper fix, because network conditions vary across the world and some themes might be smaller or bigger. :/
* I noticed that `module:download` and `site:new` also create a `Buzz` browser (that uses curl as the client).  The construction/configuration of the `Buzz` client could be done, perhaps, in a helper.
* One more thing, the following code:
```php
   try {
            if (method_exists($client, 'get')) {
                $response = $client->get($release_file_path);
            } else {
```
will never execute, because the `Curl` client from `Buzz` doesn't have a `get()`  method.  Unless, I'm wrong. xD

