### PR TITLE
[helper] Re-add Guzzle for handling file downloads

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -27,6 +27,7 @@ use Drupal\Console\EventSubscriber\ShowGenerateDocListener;
 use Drupal\Console\Helper\DrupalHelper;
 use Drupal\Console\Helper\CommandDiscoveryHelper;
 use Drupal\Console\Helper\RemoteHelper;
+use Drupal\Console\Helper\HttpClientHelper;
 
 set_time_limit(0);
 
@@ -65,6 +66,7 @@ $helpers = [
     'drupal' => new DrupalHelper(),
     'commandDiscovery' => new CommandDiscoveryHelper(),
     'remote' => new RemoteHelper(),
+    'httpClient' => new HttpClientHelper(),
 ];
 
 $application->addHelpers($helpers);

--- a/composer.json
+++ b/composer.json
@@ -53,9 +53,9 @@
         "herrera-io/phar-update": "1.*",
         "symfony/dom-crawler": "2.7.*",
         "alchemy/zippy": "0.2.*@dev",
-        "kriswallsmith/buzz": "~0.15",
         "phpseclib/phpseclib": "2.*",
-        "stecman/symfony-console-completion": "^0.5.1"
+        "stecman/symfony-console-completion": "^0.5.1",
+        "guzzlehttp/guzzle": "~6.1"
     },
     "bin": ["bin/console"],
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "214667fc5a83a571d9c929ebb6fbf0bc",
+    "hash": "669ec7ce1723a859331e0b7f5879d9c8",
+    "content-hash": "4b6189aa5584728a964cdaa4f0977b56",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -325,6 +326,177 @@
             "time": "2015-03-18 18:23:50"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "66fd14b4d0b8f2389eaf37c5458608c7cb793a81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/66fd14b4d0b8f2389eaf37c5458608c7cb793a81",
+                "reference": "66fd14b4d0b8f2389eaf37c5458608c7cb793a81",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.1",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0",
+                "psr/log": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2015-09-08 17:36:26"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "b1e1c0d55f8083c71eda2c28c12a228d708294ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/b1e1c0d55f8083c71eda2c28c12a228d708294ea",
+                "reference": "b1e1c0d55f8083c71eda2c28c12a228d708294ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2015-10-15 22:28:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
+                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-08-15 19:32:36"
+        },
+        {
             "name": "herrera-io/json",
             "version": "1.0.3",
             "source": {
@@ -550,54 +722,6 @@
             "time": "2012-08-16 17:13:03"
         },
         {
-            "name": "kriswallsmith/buzz",
-            "version": "v0.15",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kriswallsmith/Buzz.git",
-                "reference": "d4041666c3ffb379af02a92dabe81c904b35fab8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kriswallsmith/Buzz/zipball/d4041666c3ffb379af02a92dabe81c904b35fab8",
-                "reference": "d4041666c3ffb379af02a92dabe81c904b35fab8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.*"
-            },
-            "suggest": {
-                "ext-curl": "*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Buzz": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kris Wallsmith",
-                    "email": "kris.wallsmith@gmail.com",
-                    "homepage": "http://kriswallsmith.net/"
-                }
-            ],
-            "description": "Lightweight HTTP client",
-            "homepage": "https://github.com/kriswallsmith/Buzz",
-            "keywords": [
-                "curl",
-                "http client"
-            ],
-            "time": "2015-06-25 17:26:56"
-        },
-        {
             "name": "phpseclib/phpseclib",
             "version": "2.0.0",
             "source": {
@@ -730,6 +854,55 @@
                 "dependency injection"
             ],
             "time": "2013-11-22 08:30:29"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
         },
         {
             "name": "psr/log",

--- a/src/Command/SiteNewCommand.php
+++ b/src/Command/SiteNewCommand.php
@@ -14,8 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Alchemy\Zippy\Zippy;
-use Buzz\Browser;
-use Buzz\Client\Curl;
 
 class SiteNewCommand extends Command
 {
@@ -30,9 +28,8 @@ class SiteNewCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $client = new Curl();
-        $client->setTimeout(30);
-        $browser = new Browser($client);
+        $httpClient = $this->getHttpClientHelper();
+
         $site_name = $input->getArgument('site-name');
         $version = $input->getArgument('version');
 
@@ -47,8 +44,7 @@ class SiteNewCommand extends Command
 
             // Parse release module page to get Drupal 8 releases
             try {
-                $response = $browser->get($project_release_d8);
-                $html = $response->getContent();
+                $html = $httpClient->getHtml($project_release_d8);
             } catch (\Exception $e) {
                 $output->writeln('[+] <error>' . $e->getMessage() . '</error>');
                 return;
@@ -100,9 +96,7 @@ class SiteNewCommand extends Command
                 '</info>'
             );
 
-            // Save release file
-            $response = $browser->get($release_file_path);
-            file_put_contents($destination, $response->getContent());
+            $httpClient->downloadFile($release_file_path, $destination);
 
             $output->writeln(
                 '[+] <info>' .

--- a/src/Command/ThemeDownloadCommand.php
+++ b/src/Command/ThemeDownloadCommand.php
@@ -13,8 +13,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Output\OutputInterface;
 use Alchemy\Zippy\Zippy;
-use Buzz\Browser;
-use Buzz\Client\Curl;
 
 class ThemeDownloadCommand extends Command
 {
@@ -29,9 +27,7 @@ class ThemeDownloadCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $client = new Curl();
-        $client->setTimeout(30);
-        $browser = new Browser($client);
+        $httpClient = $this->getHttpClientHelper();
 
         $theme = $input->getArgument('theme');
 
@@ -49,8 +45,7 @@ class ThemeDownloadCommand extends Command
             );
 
             try {
-                $response = $browser->get('https://www.drupal.org/project/'.$theme);
-                $link = $response->getHeader('link');
+                $link = $httpClient->getHeader('https://www.drupal.org/project/'.$theme, 'link');
             } catch (\Exception $e) {
                 $output->writeln('[+] <error>' . $e->getMessage() . '</error>');
                 return;
@@ -62,8 +57,7 @@ class ThemeDownloadCommand extends Command
 
             // Parse release theme page to get Drupal 8 releases
             try {
-                $response = $browser->get($project_release_d8);
-                $html = $response->getContent();
+                $html = $httpClient->getHtml($project_release_d8);
             } catch (\Exception $e) {
                 print_r($e->getMessage());
                 $output->writeln('[+] <error>'.$e->getMessage().'</error>');
@@ -128,8 +122,7 @@ class ThemeDownloadCommand extends Command
         $destination = tempnam(sys_get_temp_dir(), 'console.').'.tar.gz';
 
         try {
-            $response = $browser->get($release_file_path);
-            file_put_contents($destination, $response->getContent());
+            $httpClient->downloadFile($release_file_path, $destination);
 
             // Determine destination folder for contrib theme
             $drupal = $this->getDrupalHelper();

--- a/src/Helper/HelperTrait.php
+++ b/src/Helper/HelperTrait.php
@@ -148,4 +148,12 @@ trait HelperTrait
     {
         return $this->getHelperSet()->get('remote');
     }
+
+    /**
+     * @return \Drupal\Console\Helper\HttpClientHelper
+     */
+    public function getHttpClientHelper()
+    {
+        return $this->getHelperSet()->get('httpClient');
+    }
 }

--- a/src/Helper/HttpClientHelper.php
+++ b/src/Helper/HttpClientHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Helper\HttpClientHelper.
+ */
+
+namespace Drupal\Console\Helper;
+
+use Drupal\Console\Helper\Helper;
+use GuzzleHttp\Client;
+
+/**
+ * Class HttpClientHelper
+ * @package \Drupal\Console\Helper\HttpClientHelper
+ */
+class HttpClientHelper extends Helper
+{
+    public function downloadFile($url, $destination)
+    {
+        $this->getClient()->get($url, array('sink' => $destination));
+    }
+
+    public function getHtml($url)
+    {
+        $response = $this->getClient()->get($url);
+
+        return (string) $response->getBody();
+    }
+
+    public function getHeader($url, $header)
+    {
+        $response = $this->getClient()->get($url);
+        $headerContent = $response->getHeader($header);
+        if (!empty($headerContent) && is_array($headerContent)) {
+            return array_shift($headerContent);
+        }
+
+        return $headerContent;
+    }
+
+    private function getClient()
+    {
+        return new Client();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'httpClient';
+    }
+}


### PR DESCRIPTION
This PR adds the following changes:
* Remove Buzz
* Add Guzzle ~6.1
* Add HttpClientHelper to re-use download logic
* Update theme:download, site:new, and module:download commands

As described on #1072, downloading stuff is unreliable due to timeouts.  Apparently, `Buzz` does not allow an empty timeout setting (see [AbstractClient](https://github.com/kriswallsmith/Buzz/blob/master/lib/Buzz/Client/AbstractClient.php#L9) and [AbstractCurl](https://github.com/kriswallsmith/Buzz/blob/master/lib/Buzz/Client/AbstractCurl.php#L210-L215)), but I might be totally wrong.  If that's the case, please let me know.

So, I began testing with latest `Guzzle` successfully.  However, `Guzzle` was used previously on the project, but due to #767 it was replaced by `Buzz`.

I tried to replicate #767, but was unable to, maybe I'm using an incorrect box build command.  My current command is simply `box build -v` inside the project directory.

Thoughts on course of action?  Can you provide the current box build command? Can you help test that this does not introduce a regression?  Thanks!!