### PR TITLE
[site:status] Check for translatable strings before calling render()

### DIFF
--- a/src/Command/SiteStatusCommand.php
+++ b/src/Command/SiteStatusCommand.php
@@ -91,9 +91,13 @@ class SiteStatusCommand extends ContainerAwareCommand
         $systemData = [];
 
         foreach ($requirements as $key => $requirement) {
-            $title = $requirement['title']->render();
-            $value = $requirement['value'];
-            $systemData['system'][$title] = $value;
+            if ($requirement['title'] instanceof \Drupal\Core\StringTranslation\TranslatableMarkup) {
+                $title = $requirement['title']->render();
+            } else {
+                $title = $requirement['title'];
+            }
+
+            $systemData['system'][$title] = $requirement['value'];
         }
 
         $kernelHelper = $this->getKernelHelper();


### PR DESCRIPTION
The `locale` module does not use `TranslatableMarkup` strings for the title of its requirements, I'm pretty sure this is by design since its status can't depend on a locale being available or completely translated.

Fixes #1082 