### PR TITLE
Add more complete instructions for Bash completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ drupal generate:module
 # You can enable autocomplete by executing
 drupal init
 
-# Bash or Zsh: Add this line to your shell configuration file
+# Bash: Bash support depends on the [bash-completion](http://bash-completion.alioth.debian.org/) project which can be installed with your package manager of choice. Then add this line to your shell configuration file.
+source "$HOME/.console/console.rc" 2>/dev/null
+
+# Zsh: Add this line to your shell configuration file.
 source "$HOME/.console/console.rc" 2>/dev/null
 
 # Fish: Create a symbolic link


### PR DESCRIPTION
SInce completion in Bash depends on [bash-completion](http://bash-completion.alioth.debian.org/) it should be noted.
