### PR TITLE
Fix minor whitespace issues in generated event subscribers

### DIFF
--- a/templates/module/src/event-subscriber.php.twig
+++ b/templates/module/src/event-subscriber.php.twig
@@ -22,12 +22,14 @@ use Symfony\Component\EventDispatcher\Event;
 class {{ class }} implements EventSubscriberInterface {% endblock %}
 
 {% block class_construct %}
+
   /**
    * Constructor.
    */
   public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
 {{ serviceClassInitialization(services) }}
   }
+
 {% endblock %}
 
 {% block class_methods %}
@@ -35,10 +37,10 @@ class {{ class }} implements EventSubscriberInterface {% endblock %}
    * {@inheritdoc}
    */
   static function getSubscribedEvents() {
-
 {% for event_name, callback in events %}
     $events['{{ event_name }}'] = ['{{ callback }}'];
 {% endfor %}
+
     return $events;
   }
 


### PR DESCRIPTION
Really minor, missing newlines after properties and constructor. Adjusted newlines in getSubscribedEvents.

Before:
```php
<?php

/**
 * @file
 * Contains Drupal\test\TestDefaultSubscriber.
 */

namespace Drupal\test\EventSubscriber;

use Symfony\Component\EventDispatcher\EventSubscriberInterface;
use Symfony\Component\EventDispatcher\Event;
use Drupal\Core\Session\AccountProxy;

/**
 * Class TestDefaultSubscriber.
 *
 * @package Drupal\test
 */
class TestDefaultSubscriber implements EventSubscriberInterface {

  /**
   * Drupal\Core\Session\AccountProxy definition.
   *
   * @var Drupal\Core\Session\AccountProxy
   */
  protected $current_user;
  /**
   * Constructor.
   */
  public function __construct(AccountProxy $current_user) {
    $this->current_user = $current_user;
  }
  /**
   * {@inheritdoc}
   */
  static function getSubscribedEvents() {

    $events['kernel.request'] = ['kernel_request'];
    return $events;
  }

  /**
   * This method is called whenever the kernel.request event is
   * dispatched.
   *
   * @param GetResponseEvent $event
   */
  public function kernel_request(Event $event) {
    drupal_set_message('Event kernel.request thrown by Subscriber in module test.', 'status', TRUE);
  }

}
```
After:
```php
<?php

/**
 * @file
 * Contains Drupal\test\TestDefaultSubscriber.
 */

namespace Drupal\test\EventSubscriber;

use Symfony\Component\EventDispatcher\EventSubscriberInterface;
use Symfony\Component\EventDispatcher\Event;
use Drupal\Core\Session\AccountProxy;

/**
 * Class TestDefaultSubscriber.
 *
 * @package Drupal\test
 */
class TestDefaultSubscriber implements EventSubscriberInterface {

  /**
   * Drupal\Core\Session\AccountProxy definition.
   *
   * @var Drupal\Core\Session\AccountProxy
   */
  protected $current_user;

  /**
   * Constructor.
   */
  public function __construct(AccountProxy $current_user) {
    $this->current_user = $current_user;
  }

  /**
   * {@inheritdoc}
   */
  static function getSubscribedEvents() {
    $events['kernel.request'] = ['kernel_request'];

    return $events;
  }

  /**
   * This method is called whenever the kernel.request event is
   * dispatched.
   *
   * @param GetResponseEvent $event
   */
  public function kernel_request(Event $event) {
    drupal_set_message('Event kernel.request thrown by Subscriber in module test.', 'status', TRUE);
  }

}
```