### PR TITLE
Bad copy/paste commands.update between debug and execute

### DIFF
--- a/src/Command/UpdateExecuteCommand.php
+++ b/src/Command/UpdateExecuteCommand.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\Console\Command\RestDebugCommand.
+ * Contains \Drupal\Console\Command\UpdateExecuteCommand.
  */
 
 namespace Drupal\Console\Command;
@@ -20,9 +20,9 @@ class UpdateExecuteCommand extends ContainerAwareCommand
     {
         $this
             ->setName('update:execute')
-            ->setDescription($this->trans('commands.update.debug.description'))
+            ->setDescription($this->trans('commands.update.execute.description'))
             ->addArgument('module', InputArgument::REQUIRED, $this->trans('commands.common.options.module'))
-            ->addArgument('update-n', InputArgument::OPTIONAL, $this->trans('commands.update.debug.options.update-n'));
+            ->addArgument('update-n', InputArgument::OPTIONAL, $this->trans('commands.update.execute.options.update-n'));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
I'm in Drupal Console version 0.9.5.

When i make <code>drupal list</code>, i have
<code>
update
  update:debug                      Display current updates available for the application
  update:execute                    Display current updates available for the application
</code>

Seems UpdateExecuteCommand.php does some references to update:debug command. Replace them by execute.