### PR TITLE
Fixes the currently broken get of existing entity-langcode

### DIFF
--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -33,7 +33,7 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
     $form['langcode'] = array(
       '#title' => $this->t('Language'),
       '#type' => 'language_select',
-      '#default_value' =>  $entity->langcode->value,
+      '#default_value' => $entity->langcode->value,
       '#languages' => Language::STATE_ALL,
     );
 

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -33,7 +33,7 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
     $form['langcode'] = array(
       '#title' => $this->t('Language'),
       '#type' => 'language_select',
-      '#default_value' => $entity->getUntranslated()->language()->getId(),
+      '#default_value' =>  $entity->langcode->value,
       '#languages' => Language::STATE_ALL,
     );
 


### PR DESCRIPTION
The current code for getting the entity langcode is broken, I'm not entirely sure this is the correct way of doing this but it does work when editing existing entities.

I also found https://www.drupal.org/node/2303877 which hints using "language()->getId()" should be avoided for content entities.