### PR TITLE
Add multisite support

### DIFF
--- a/config/translations/en/application.yml
+++ b/config/translations/en/application.yml
@@ -8,6 +8,7 @@ console:
         generate-chain: 'Print execution options and arguments as yaml output to be used in chain command'
         generate-inline: 'Print execution options and arguments as inline call to be use in the future'
         root: 'Define the Drupal root to be use in command execution'
+        uri: 'URI of the Drupal site to use (for multisite environments or when running on an alternate port)'
     messages:
         completed: 'The command was executed successfully!'
         chain:

--- a/src/Application.php
+++ b/src/Application.php
@@ -91,6 +91,9 @@ class Application extends BaseApplication
         $this->getDefinition()->addOption(
             new InputOption('--target', '--t', InputOption::VALUE_OPTIONAL, $this->trans('application.console.arguments.target'))
         );
+        $this->getDefinition()->addOption(
+          new InputOption('--uri', '-l', InputOption::VALUE_REQUIRED, $this->trans('application.console.arguments.uri'))
+        );
     }
 
     /**
@@ -166,6 +169,7 @@ class Application extends BaseApplication
             $root = $input->getParameterOption(['--root'], null);
         }
 
+        $uri = $input->getParameterOption(array('--uri', '-l'));
         $env = $input->getParameterOption(array('--env', '-e'), getenv('DRUPAL_ENV') ?: 'prod');
 
         $debug = getenv('DRUPAL_DEBUG') !== '0'
@@ -193,10 +197,10 @@ class Application extends BaseApplication
             }
         } else {
             chdir($drupal->getRoot());
-            $site->setSitePath($drupal->getRoot());
+            $site->setSiteRoot($drupal->getRoot());
 
             if ($drupal->isValidInstance()) {
-                $this->bootDrupal($env, $debug, $drupal);
+                $this->bootDrupal($env, $debug, $drupal, $uri);
             }
 
             if ($drupal->isInstalled()) {
@@ -270,8 +274,9 @@ class Application extends BaseApplication
      * @param string     $env
      * @param bool|false $debug
      * @param $drupal
+     * @param string     $uri
      */
-    private function bootDrupal($env = 'prod', $debug = false, $drupal)
+    private function bootDrupal($env = 'prod', $debug = false, $drupal, $uri = '')
     {
         if ($debug) {
             Debug::enable();
@@ -279,6 +284,7 @@ class Application extends BaseApplication
 
         $kernelHelper = $this->getKernelHelper();
 
+        $kernelHelper->setRequestUri($uri);
         $kernelHelper->setDebug($debug);
         $kernelHelper->setEnvironment($env);
         $kernelHelper->setClassLoader($drupal->getAutoLoadClass());

--- a/src/Command/SiteStatusCommand.php
+++ b/src/Command/SiteStatusCommand.php
@@ -101,6 +101,7 @@ class SiteStatusCommand extends ContainerAwareCommand
         }
 
         $kernelHelper = $this->getKernelHelper();
+//        $site = $this->getSiteHelper();
         $drupal = $this->getDrupalHelper();
 
         Settings::initialize(

--- a/src/Command/SiteStatusCommand.php
+++ b/src/Command/SiteStatusCommand.php
@@ -101,12 +101,11 @@ class SiteStatusCommand extends ContainerAwareCommand
         }
 
         $kernelHelper = $this->getKernelHelper();
-//        $site = $this->getSiteHelper();
         $drupal = $this->getDrupalHelper();
 
         Settings::initialize(
             $drupal->getRoot(),
-            'sites/default',
+            $kernelHelper->getSitePath(),
             $kernelHelper->getClassLoader()
         );
 

--- a/src/Helper/DrupalHelper.php
+++ b/src/Helper/DrupalHelper.php
@@ -28,7 +28,7 @@ class DrupalHelper extends Helper
 {
     const DRUPAL_AUTOLOAD = 'autoload.php';
 
-    const DRUPAL_SETTINGS = 'sites/default/settings.php';
+    const DEFAULT_SETTINGS_PHP = 'sites/default/settings.php';
 
     /**
      * @var string
@@ -87,7 +87,7 @@ class DrupalHelper extends Helper
      */
     private function isSettingsFile()
     {
-        $settingsPath = sprintf('%s/%s', $this->root, self::DRUPAL_SETTINGS);
+        $settingsPath = sprintf('%s/%s', $this->root, self::DEFAULT_SETTINGS_PHP);
 
         return file_exists($settingsPath);
     }

--- a/src/Helper/KernelHelper.php
+++ b/src/Helper/KernelHelper.php
@@ -190,6 +190,13 @@ class KernelHelper extends Helper
         return $this->request;
     }
 
+  /**
+   *
+   */
+    public function getSitePath() {
+        return $this->getKernel()->getSitePath();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Helper/KernelHelper.php
+++ b/src/Helper/KernelHelper.php
@@ -46,6 +46,11 @@ class KernelHelper extends Helper
     protected $debug;
 
     /**
+     * @var string
+     */
+    protected $requestUri;
+
+    /**
      * @var bool
      */
     protected $booted;
@@ -64,6 +69,13 @@ class KernelHelper extends Helper
     public function setDebug($debug)
     {
         $this->debug = $debug;
+    }
+
+    /**
+     * @param string $requestUri
+     */
+    public function setRequestUri($requestUri) {
+        $this->requestUri = $requestUri;
     }
 
     /**
@@ -99,7 +111,14 @@ class KernelHelper extends Helper
         }
 
         if (!$this->kernel) {
-            $this->request = Request::createFromGlobals();
+            if ($this->requestUri) {
+                $this->request = Request::create($this->requestUri);
+                $this->request->server->set('SCRIPT_NAME', '/index.php');
+            }
+            else {
+                $this->request = Request::createFromGlobals();
+            }
+
             $this->kernel = DrupalKernel::createFromRequest(
                 $this->request,
                 $this->classLoader,

--- a/src/Helper/SiteHelper.php
+++ b/src/Helper/SiteHelper.php
@@ -25,22 +25,22 @@ class SiteHelper extends Helper
     /**
      * @var string
      */
-    private $sitePath;
+    private $siteRoot;
 
     /**
      * @return string
      */
-    public function getSitePath()
+    public function getSiteRoot()
     {
-        return $this->sitePath;
+        return $this->siteRoot;
     }
 
     /**
-     * @param string $sitePath
+     * @param string $siteRoot
      */
-    public function setSitePath($sitePath)
+    public function setSiteRoot($siteRoot)
     {
-        $this->sitePath = $sitePath;
+        $this->siteRoot = $siteRoot;
     }
 
     /**
@@ -138,7 +138,7 @@ class SiteHelper extends Helper
 
         $modulePath = sprintf(
             '%s/%s',
-            $this->sitePath,
+            $this->siteRoot,
             $this->modules[$moduleName]->getPath()
         );
 
@@ -146,7 +146,7 @@ class SiteHelper extends Helper
             $modulePath = str_replace(
                 sprintf(
                     '%s/',
-                    $this->sitePath
+                    $this->siteRoot
                 ),
                 '',
                 $modulePath


### PR DESCRIPTION
This patch adds support for multisite Drupal environments as requested in Issue #755 .  It allows a user to specify which site to query or configure by using the --uri / -l command-line options (similar to drush).  The DrupalKernel code itself is utilized to determine which site and site path corresponds to the URI specified, avoiding possible duplication of code.

I also made a couple of other minor changes to avoid potential confusion:
- changed `$sitePath` in `SiteHelper` to `$siteRoot`
- renamed the `DRUPAL_SETTINGS` constant in `DrupalHelper` to `DEFAULT_SETTINGS_PHP`