### PR TITLE
[site:mode] Do not disable Twig cache in dev mode

### DIFF
--- a/src/Command/Site/ModeCommand.php
+++ b/src/Command/Site/ModeCommand.php
@@ -201,7 +201,7 @@ class ModeCommand extends ContainerAwareCommand
             'twig.config' => [
                 'debug' => ['dev' => true, 'prod' => false],
                 'auto_reload' =>['dev' => true, 'prod' => false],
-                'cache' => ['dev' => false, 'prod' => true]
+                'cache' => ['dev' => true, 'prod' => true]
             ]
         ];
 


### PR DESCRIPTION
## Problem/Motivation

When you use debug (or just auto_reload if you for some reason don't want debug on) the Twig cache doesn't get in your way. Disabling the Twig cache just makes for a slower development experience because each template needs to be compiled regardless of if it's been edited or not. Also, you can't easily debug/look at the compiled Twig templates (PHP classes) if they are not cached.

## How to reproduce

n/a I think, this is not a bug report.

## Solution

Leave Twig cache alone! I think 99.9999% of the time developers should only touch debug, and leave auto_reload and cache alone. I would argue that auto_reload can be left as `null` but don't want to scope creep :)