### PR TITLE
fix missing curly braces

### DIFF
--- a/templates/theme/theme.twig
+++ b/templates/theme/theme.twig
@@ -54,7 +54,7 @@ function {{ machine_name }}_preprocess_page(array &$variables) {
  */
 function {{ machine_name }}_theme_suggestions_page_alter(array &$suggestions, array $variables) {
 
-}{
+}
 
 /**
  * Implements hook_theme_suggestions_node_alter().


### PR DESCRIPTION
This PR fix a syntax error when enable a theme created with the `generate:theme` command