### PR TITLE
Add exit code for Application::doRun()

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -228,7 +228,7 @@ class Application extends BaseApplication
 
         if (true === $input->hasParameterOption(['--shell', '-s'])) {
             $this->runShell($input);
-            return;
+            return 0;
         }
 
         if (true === $input->hasParameterOption(array('--generate-doc', '--gd'))) {
@@ -240,7 +240,7 @@ class Application extends BaseApplication
             );
         }
 
-        parent::doRun($input, $output);
+        return parent::doRun($input, $output);
     }
 
     /**


### PR DESCRIPTION
Symfony console application expected that method doRun() will return an exit code: zero if everything went fine, or an error code.
It prevents `The command terminated with an error status ()` error after every command in console.