### PR TITLE
[template] Fix deprecated function usage

### DIFF
--- a/templates/module/src/entity-listbuilder.php.twig
+++ b/templates/module/src/entity-listbuilder.php.twig
@@ -32,7 +32,7 @@ class {{ entity_class }}ListBuilder extends ConfigEntityListBuilder {% endblock 
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
-    $row['label'] = $this->getLabel($entity);
+    $row['label'] = $entity->label();
     $row['id'] = $entity->id();
     // You probably want a few more properties here...
     return $row + parent::buildRow($entity);

--- a/templates/module/src/listbuilder-entity-content.php.twig
+++ b/templates/module/src/listbuilder-entity-content.php.twig
@@ -42,7 +42,7 @@ class {{ entity_class }}ListBuilder extends EntityListBuilder {% endblock %}
     /* @var $entity \Drupal\{{module}}\Entity\{{ entity_class }} */
     $row['id'] = $entity->id();
     $row['name'] = $this->l(
-      $this->getLabel($entity),
+      $entity->label(),
       new Url(
         'entity.{{ entity_name }}.edit_form', array(
           '{{ entity_name }}' => $entity->id(),


### PR DESCRIPTION
Method EntityListBuilder::getLabel() is deprecated, use $entity->label() instead.

Link to the docs:  
https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Entity!EntityListBuilder.php/function/EntityListBuilder%3A%3AgetLabel/8