### PR TITLE
Enable browser zoom on mobile devices

### DIFF
--- a/templates/theme/theme.twig
+++ b/templates/theme/theme.twig
@@ -22,14 +22,6 @@ function {{ machine_name }}_preprocess_html(array &$variables) {
  * Implements hook_page_attachments_alter().
  */
 function {{ machine_name }}_page_attachments_alter(array &$page) {
-  // Disabling browser zoom on mobile devices.
-  /*foreach ($page['#attached']['html_head'] as &$meta_arr) {
-    if (array_search('viewport', $meta_arr)) {
-      $meta_arr[0]['#attributes']['content'] .= ', maximum-scale=1.0, user-scalable=0';
-    }
-  }*/
-
-
   // Tell IE to use latest rendering engine (not to use compatibility mode).
   /*$ie_edge = [
     '#type' => 'html_tag',


### PR DESCRIPTION
Removing browser zoom on mobile devices is an anti-pattern that harms accessibility. There are many people that need to pinch and zoom in a browser to see things better. The default theme generation code should not remove that ability.