### PR TITLE
Search themes for commands as well as modules.

### DIFF
--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -20,6 +20,11 @@ abstract class Command extends BaseCommand
     protected $module;
 
     /**
+     * @var string
+     */
+    protected $theme;
+
+    /**
      * @var array
      */
     protected $dependencies;
@@ -50,6 +55,22 @@ abstract class Command extends BaseCommand
     }
 
     /**
+     * @return string
+     */
+    public function getTheme()
+    {
+      return $this->theme;
+    }
+
+    /**
+     * @param string $theme
+     */
+    public function setTheme($theme)
+    {
+      $this->theme = $theme;
+    }
+
+    /**
      * @param $key string
      *
      * @return string
@@ -60,13 +81,13 @@ abstract class Command extends BaseCommand
     }
 
     /**
-     * @param $moduleName string
+     * @param $sourceName string
      *
-     * @param $moduleName
+     * @param $sourceName
      */
-    public function addDependency($moduleName)
+    public function addDependency($sourceName)
     {
-        $this->dependencies[] = $moduleName;
+        $this->dependencies[] = $sourceName;
     }
 
     /**

--- a/src/Command/Theme/DebugCommand.php
+++ b/src/Command/Theme/DebugCommand.php
@@ -29,7 +29,7 @@ class DebugCommand extends ContainerAwareCommand
         $table = $this->getTableHelper();
         $table->setlayout($table::LAYOUT_COMPACT);
         if ($theme) {
-            $this->getTheme($theme, $output, $table);
+            $this->getThemeForDebug($theme, $output, $table);
         } else {
             $this->getAllThemes($output, $table);
         }
@@ -55,7 +55,7 @@ class DebugCommand extends ContainerAwareCommand
         $table->render($output);
     }
 
-    protected function getTheme($themeId, $output, $table)
+    protected function getThemeForDebug($themeId, $output, $table)
     {
         $theme = null;
         $message = $this->getMessageHelper();

--- a/src/Helper/CommandDiscoveryHelper.php
+++ b/src/Helper/CommandDiscoveryHelper.php
@@ -206,7 +206,12 @@ class CommandDiscoveryHelper extends Helper
 
         if ($reflectionClass->getConstructor()->getNumberOfRequiredParameters() > 0) {
             if ($source != 'Console' && $type === 'module') {
-                $this->getTranslator()->addResourceTranslationsBySource($source);
+                if ($type === 'module') {
+                  $this->getTranslator()->addResourceTranslationsByModule($source);
+                }
+                else if ($type === 'theme') {
+                  $this->getTranslator()->addResourceTranslationsByTheme($source);
+                }
             }
             $command = $reflectionClass->newInstance($this->getHelperSet());
         } else {

--- a/src/Helper/CommandDiscoveryHelper.php
+++ b/src/Helper/CommandDiscoveryHelper.php
@@ -64,7 +64,7 @@ class CommandDiscoveryHelper extends Helper
         $customModuleCommands = $this->getCustomCommands();
         $customThemeCommands = $this->getCustomCommands('themes');
 
-        return array_merge($consoleCommands, $customModuleCommands, $customThemeCommands);
+        return array_merge($consoleCommands, array_merge($customModuleCommands, $customThemeCommands));
     }
 
     /**

--- a/src/Helper/SiteHelper.php
+++ b/src/Helper/SiteHelper.php
@@ -57,7 +57,7 @@ class SiteHelper extends Helper
 
         return $discovery->scan('module');
     }
-    
+
     /**
      * @return \Drupal\Core\Extension\Extension[]
      */

--- a/src/Helper/SiteHelper.php
+++ b/src/Helper/SiteHelper.php
@@ -57,6 +57,21 @@ class SiteHelper extends Helper
 
         return $discovery->scan('module');
     }
+    
+    /**
+     * @return \Drupal\Core\Extension\Extension[]
+     */
+    private function discoverThemes()
+    {
+        /*
+         * @see Remove DrupalExtensionDiscovery subclass once
+         * https://www.drupal.org/node/2503927 is fixed.
+         */
+        $discovery = new DrupalExtensionDiscovery(\Drupal::root());
+        $discovery->reset();
+
+        return $discovery->scan('theme');
+    }
 
     /**
      * @return array
@@ -80,6 +95,30 @@ class SiteHelper extends Helper
             return [];
         }
         return $coreExtension->get('module') ?: [];
+    }
+    
+    /**
+     * @return array
+     */
+    private function getInstalledThemes()
+    {
+        $kernel = $this->getKernelHelper()->getKernel();
+        if (!$kernel) {
+            return [];
+        }
+        $container = $kernel->getContainer();
+        if (!$container) {
+            return [];
+        }
+        $configFactory = $container->get('config.factory');
+        if (!$configFactory) {
+            return [];
+        }
+        $coreExtension = $configFactory->get('core.extension');
+        if (!$coreExtension) {
+            return [];
+        }
+        return $coreExtension->get('theme') ?: [];
     }
 
     /**
@@ -123,6 +162,39 @@ class SiteHelper extends Helper
         }
 
         return $modules;
+    }
+    
+    /**
+     * @param bool|false $reset
+     * @param bool|false $installedOnly
+     * @param bool|false $nameOnly
+     * @return array
+     */
+    public function getThemes(
+        $reset = false,
+        $installedOnly = false,
+        $nameOnly = false
+    ) {
+        $installedThemes = $this->getInstalledThemes();
+        $themes = [];
+
+        if (!$this->themes || $reset) {
+            $this->themes = $this->discoverThemes();
+        }
+
+        foreach ($this->themes as $theme) {
+            $name = $theme->getName();
+            if ($installedOnly && !array_key_exists($name, $installedThemes)) {
+                continue;
+            }
+            if ($nameOnly) {
+                $themes[] = $name;
+            } else {
+                $themes[$name] = $theme;
+            }
+        }
+
+        return $themes;
     }
 
     /**

--- a/src/Helper/TranslatorHelper.php
+++ b/src/Helper/TranslatorHelper.php
@@ -206,6 +206,77 @@ class TranslatorHelper extends Helper
     }
 
     /**
+     * @param $theme
+     */
+    public function addResourceTranslationsByTheme($theme)
+    {
+      $resource = $this->getDrupalHelper()->getRoot().'/'.drupal_get_path('theme', $theme).
+        '/config/translations/console.'.$this->language.'.yml';
+
+      if (file_exists($resource)) {
+        $this->addResource($resource);
+      } else {
+        // Try to load the language fallback
+        $resource_fallback = $this->getDrupalHelper()->getRoot().'/'.drupal_get_path('theme', $theme).
+          '/config/translations/console.en.yml';
+        if (file_exists($resource_fallback)) {
+          $this->addResource($resource_fallback);
+        }
+      }
+    }
+
+    /**
+     * @param $theme
+     * @param $messages
+     */
+    public function writeTranslationsByTheme($theme, $messages)
+    {
+      $currentMessages = $this->getMessagesByModule($theme);
+
+      $language = 'en';
+      $resource = $this->getDrupalHelper()->getRoot().'/'.drupal_get_path('theme', $theme).
+        '/config/translations/';
+
+      $messageCatalogue = new MessageCatalogue($language);
+      if ($currentMessages && $currentMessages['messages']) {
+        $messageCatalogue->add($currentMessages['messages'], 'console');
+      }
+      $messageCatalogue->add($messages, 'console');
+
+      $translatorWriter = new TranslationWriter();
+      $translatorWriter->addDumper('yaml', new YamlFileDumper());
+      $translatorWriter->writeTranslations(
+        $messageCatalogue,
+        'yaml',
+        ['path' => $resource, 'nest-level' => 10, 'indent' => 2]
+      );
+    }
+
+    /**
+     * @param $theme
+     * @return array
+     */
+    protected function getMessagesByTheme($theme)
+    {
+      $resource = $this->getDrupalHelper()->getRoot().'/'.drupal_get_path('theme', $theme).
+        '/config/translations/console.'.$this->language.'.yml';
+
+      if (file_exists($resource)) {
+        $themeTranslator = new Translator($this->language);
+        $themeTranslator->addLoader('yaml', new YamlFileLoader());
+        $themeTranslator->addResource(
+          'yaml',
+          $resource,
+          $this->language
+        );
+
+        return $themeTranslator->getMessages($this->language);
+      }
+
+      return [];
+    }
+
+    /**
      * @param $key
      * @return string
      */


### PR DESCRIPTION
This PR is not functional as is, but I wanted to start a conversation to look at the possibility of having themes provide their own commands as well as modules. I found a few of the spots where changes need to be made in order for this to work, but I'm sure there are more.

One of the advantages of allowing themes to provide their own commands is so they could add their own generate functions to be able to generate sub-themes based on the specific needs of that particular theme. There may well be other cases where it would be useful for themes to provide Drupal Console custom commands as well.