### PR TITLE
[server] Add new command

### DIFF
--- a/config/translations/en/server.yml
+++ b/config/translations/en/server.yml
@@ -5,3 +5,10 @@ messages:
   executing: Executing php from %s.
 errors:
   binary: Unable to find PHP binary to run server.
+examples:
+  - description: Run using default address argument value 127.0.0.1.8088
+    execution: drupal server
+  - description: Passing address argument to use a different port number
+    execution: drupal server 127.0.0.1:8089
+  - description: Running default address argument values, using --root option to define the Drupal root
+    execution: drupal --root=/Users/jmolivas/develop/drupal/sites/drupal8.dev server

--- a/config/translations/en/server.yml
+++ b/config/translations/en/server.yml
@@ -1,0 +1,7 @@
+description: 'Runs PHP built-in web server'
+arguments:
+  address: The address:port values
+messages:
+  executing: Executing php from %s.
+errors:
+  binary: Unable to find PHP binary to run server.

--- a/config/translations/en/server.yml
+++ b/config/translations/en/server.yml
@@ -11,4 +11,4 @@ examples:
   - description: Passing address argument to use a different port number
     execution: drupal server 127.0.0.1:8089
   - description: Running default address argument values, using --root option to define the Drupal root
-    execution: drupal --root=/Users/jmolivas/develop/drupal/sites/drupal8.dev server
+    execution: drupal --root=/var/www/drupal8.dev server

--- a/src/Command/Develop/GenerateDocGitbookCommand.php
+++ b/src/Command/Develop/GenerateDocGitbookCommand.php
@@ -21,7 +21,8 @@ class GenerateDocGitbookCommand extends ContainerAwareCommand
       'help',
       'init',
       'list',
-      'self-update'
+      'self-update',
+      'server'
     ];
 
     /**

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\ServerCommand.
+ */
+
+namespace Drupal\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ServerCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('server')
+            ->setDescription($this->trans('commands.server.description'))
+            ->addArgument(
+                'address',
+                InputArgument::OPTIONAL,
+                $this->trans('commands.server.arguments.address'),
+                '127.0.0.1:8088'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output = new SymfonyStyle($input, $output);
+
+        $address = $input->getArgument('address');
+        if (false === strpos($address, ':')) {
+            $address = sprintf(
+                '%s:8088',
+                $addres
+            );
+        }
+
+        $finder = new PhpExecutableFinder();
+        if (false === $binary = $finder->find()) {
+            $output->error($this->trans('commands.server.errors.binary'));
+            return;
+        }
+
+        $output->success(
+            sprintf(
+                $this->trans('commands.server.messages.executing'),
+                $binary
+            )
+        );
+
+        $processBuilder = new ProcessBuilder([$binary, '-S', $address]);
+        $process = $processBuilder->getProcess();
+        $process->setWorkingDirectory($this->getDrupalHelper()->getRoot());
+        $process->setTty('true');
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException($process->getErrorOutput());
+        }
+    }
+}


### PR DESCRIPTION
## How to use
```
# Run using default address argument value 127.0.0.1.8088
$ drupal server

# Passing address argument to use a different port number
$ drupal server 127.0.0.1:8089

# Running default address argument using --root option to define the Drupal root 
$ drupal --root=/Users/jmolivas/develop/drupal/sites/drupal8.dev server
```

![drupal-console-server](https://cloud.githubusercontent.com/assets/366275/11416709/32fb1f5e-93c5-11e5-9f57-bbd82a7f4613.png)
