### PR TITLE
Use Psr/Log

### DIFF
--- a/src/Helper/MessageHelper.php
+++ b/src/Helper/MessageHelper.php
@@ -7,22 +7,27 @@
 
 namespace Drupal\Console\Helper;
 
+use \Psr\Log\LoggerInterface;
+use \Psr\Log\LoggerTrait;
+use \Psr\Log\LogLevel;
 use Drupal\Console\Helper\Helper;
 
-class MessageHelper extends Helper
+class MessageHelper extends Helper implements LoggerInterface
 {
+    use LoggerTrait;
+
     /**
      * @var string
      */
-    const MESSAGE_ERROR = 'error';
+    const MESSAGE_ERROR = LogLevel::ERROR;
     /**
      * @var string
      */
-    const MESSAGE_WARNING = 'warning';
+    const MESSAGE_WARNING = LogLevel::WARNING;
     /**
      * @var string
      */
-    const MESSAGE_INFO = 'info';
+    const MESSAGE_INFO = LogLevel::INFO;
     /**
      * @var string
      */
@@ -30,7 +35,7 @@ class MessageHelper extends Helper
     /**
      * @var string
      */
-    const MESSAGE_DEFAULT = 'default';
+    const MESSAGE_DEFAULT = LogLevel::NOTICE;
 
     /**
      * @var array
@@ -120,6 +125,13 @@ class MessageHelper extends Helper
         }
 
         $output->writeln($outputMessage);
+    }
+
+    /**
+     *  @inheritdoc
+     */
+    public function log($level, $message, array $context = array()) {
+        $this->addMessage($message, $type);
     }
 
     /**


### PR DESCRIPTION
Make MessageHelper implement LoggerInterface, so that it may be provided to any class that needs a Prs\Log-compatible logger.  The purpose here is to help enable code sharing, although at this particular time there is no candidate code to share.

I do find it somewhat troubling that Symfony/Console does not use Psr/Log, but since DrupalConsole already happens to have a MessageHelper, this extension is somewhat natural.