### PR TITLE
#1396: add PHP7 to travis tests fix #1396

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
 matrix:
   allow_failures:
     - php: hhvm
+    - php: 7
 
 env:
   global:


### PR DESCRIPTION
add PHP 7 to travis tests and flag it as "allowed_failure"