### PR TITLE
[console] Fix "temporary" spelling mistakes

### DIFF
--- a/Test/BaseTestCase.php
+++ b/Test/BaseTestCase.php
@@ -21,10 +21,10 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setup()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
     }
 
-    public function setUpTemporalDirectory()
+    public function setUpTemporaryDirectory()
     {
         $this->dir = sys_get_temp_dir() . "/modules";
     }

--- a/Test/DataProvider/AuthenticationProviderDataProviderTrait.php
+++ b/Test/DataProvider/AuthenticationProviderDataProviderTrait.php
@@ -13,7 +13,7 @@ trait AuthenticationProviderDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), 0],

--- a/Test/DataProvider/CommandDataProviderTrait.php
+++ b/Test/DataProvider/CommandDataProviderTrait.php
@@ -13,7 +13,7 @@ trait CommandDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
             ['command_' . rand(), 'command:default', 'CommandDefault', false],

--- a/Test/DataProvider/ConfigFormBaseDataProviderTrait.php
+++ b/Test/DataProvider/ConfigFormBaseDataProviderTrait.php
@@ -13,7 +13,7 @@ trait ConfigFormBaseDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), 'Bar', null, null, 'ConfigFormBase', null],

--- a/Test/DataProvider/ControllerDataProviderTrait.php
+++ b/Test/DataProvider/ControllerDataProviderTrait.php
@@ -13,7 +13,7 @@ trait ControllerDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         $routes = [
           ['title' => 'Foo Controller', 'method' => 'index', 'route' => 'index']

--- a/Test/DataProvider/EntityBundleDataProviderTrait.php
+++ b/Test/DataProvider/EntityBundleDataProviderTrait.php
@@ -13,7 +13,7 @@ trait EntityBundleDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
         
         return [
           ['foo', 'default_type', 'default']

--- a/Test/DataProvider/EntityConfigDataProviderTrait.php
+++ b/Test/DataProvider/EntityConfigDataProviderTrait.php
@@ -13,7 +13,7 @@ trait EntityConfigDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), 'Bar', 'bar'],

--- a/Test/DataProvider/EntityContentDataProviderTrait.php
+++ b/Test/DataProvider/EntityContentDataProviderTrait.php
@@ -13,7 +13,7 @@ trait EntityContentDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), 'Bar', 'bar'],

--- a/Test/DataProvider/EntityDataProviderTrait.php
+++ b/Test/DataProvider/EntityDataProviderTrait.php
@@ -13,7 +13,7 @@ trait EntityDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'Bar', 'foo' . rand(), 'bar'],

--- a/Test/DataProvider/FormDataProviderTrait.php
+++ b/Test/DataProvider/FormDataProviderTrait.php
@@ -13,7 +13,7 @@ trait FormDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
         
         return [
           ['Foo', 'foo' . rand(), 'id' . rand(), null, null, 'FormBase', true]

--- a/Test/DataProvider/ModuleDataProviderTrait.php
+++ b/Test/DataProvider/ModuleDataProviderTrait.php
@@ -13,7 +13,7 @@ trait ModuleDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), $this->dir, 'Description', '8.x', 'Other', false, false, null],

--- a/Test/DataProvider/PermissionDataProviderTrait.php
+++ b/Test/DataProvider/PermissionDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PermissionDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'my permissions'],

--- a/Test/DataProvider/PluginBlockDataProviderTrait.php
+++ b/Test/DataProvider/PluginBlockDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginBlockDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'foo', 'bar', null, '', 'inputs'],

--- a/Test/DataProvider/PluginConditionDataProviderTrait.php
+++ b/Test/DataProvider/PluginConditionDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginConditionDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'foo', 'bar-id', 'foo-context-id', 'foo-context-label', false]

--- a/Test/DataProvider/PluginFieldDataProviderTrait.php
+++ b/Test/DataProvider/PluginFieldDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginFieldDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'foo', 'foo-bar', 'foo-bar', 'bar', 'Foo-Bar', 'foo-bar', 'foo-bar', 'bar', 'Foo-Bar', 'foo-bar', 'foo-bar', 'bar']

--- a/Test/DataProvider/PluginFieldFormatterDataProviderTrait.php
+++ b/Test/DataProvider/PluginFieldFormatterDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginFieldFormatterDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'bar', 'bar' . rand(), 'foo-bar']

--- a/Test/DataProvider/PluginFieldTypeDataProviderTrait.php
+++ b/Test/DataProvider/PluginFieldTypeDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginFieldTypeDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'foo', 'foo-bar', 'foo-bar', 'bar', 'Foo-Bar']

--- a/Test/DataProvider/PluginFieldWidgetDataProviderTrait.php
+++ b/Test/DataProvider/PluginFieldWidgetDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginFieldWidgetDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'foo', 'foo-bar', 'Foo-Bar']

--- a/Test/DataProvider/PluginImageEffectDataProviderTrait.php
+++ b/Test/DataProvider/PluginImageEffectDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginImageEffectDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'foo', 'bar', 'description'],

--- a/Test/DataProvider/PluginImageFormatterDataProviderTrait.php
+++ b/Test/DataProvider/PluginImageFormatterDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginImageFormatterDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo',  'foo' . rand(), 'foo', 'bar'],

--- a/Test/DataProvider/PluginRestResourceDataProviderTrait.php
+++ b/Test/DataProvider/PluginRestResourceDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginRestResourceDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), 'Foo', 'pluginID' . rand(), 'url', 'states'],

--- a/Test/DataProvider/PluginRulesActionDataProviderTrait.php
+++ b/Test/DataProvider/PluginRulesActionDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginRulesActionDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), 'Foo', 'pluginID' . rand(), 'category', 'context', 'bar'],

--- a/Test/DataProvider/PluginTypeAnnotationDataProviderTrait.php
+++ b/Test/DataProvider/PluginTypeAnnotationDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginTypeAnnotationDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'MyPlugin', 'my_plugin', 'my.plugin'],

--- a/Test/DataProvider/PluginTypeYamlDataProviderTrait.php
+++ b/Test/DataProvider/PluginTypeYamlDataProviderTrait.php
@@ -13,7 +13,7 @@ trait PluginTypeYamlDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'MyPlugin', 'my_plugin', 'my.plugin'],

--- a/Test/DataProvider/ServiceDataProviderTrait.php
+++ b/Test/DataProvider/ServiceDataProviderTrait.php
@@ -13,7 +13,7 @@ trait ServiceDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', 'foo' . rand(), 'Foo', false, []],

--- a/Test/DataProvider/ThemeDataProviderTrait.php
+++ b/Test/DataProvider/ThemeDataProviderTrait.php
@@ -13,7 +13,7 @@ trait ThemeDataProviderTrait
      */
     public function commandData()
     {
-        $this->setUpTemporalDirectory();
+        $this->setUpTemporaryDirectory();
 
         return [
           ['Foo', rand(), $this->dir.'/themes/custom', 'bar', 'Other', '8.x', 'sd', 'global-styling', false, false]

--- a/src/Command/Config/EditCommand.php
+++ b/src/Command/Config/EditCommand.php
@@ -49,8 +49,8 @@ class EditCommand extends ContainerAwareCommand
         $editor = $input->getArgument('editor');
         $config = $this->getConfigFactory()->getEditable($configName);
         $configSystem = $this->getConfigFactory()->get('system.file');
-        $temporalyDirectory = $configSystem->get('path.temporary') ?: '/tmp';
-        $configFile = $temporalyDirectory.'/config-edit/'.$configName.'.yml';
+        $temporaryDirectory = $configSystem->get('path.temporary') ?: '/tmp';
+        $configFile = $temporaryDirectory.'/config-edit/'.$configName.'.yml';
         $ymlFile = new Parser();
         $fileSystem = new Filesystem();
 
@@ -59,7 +59,7 @@ class EditCommand extends ContainerAwareCommand
         }
 
         try {
-            $fileSystem->mkdir($temporalyDirectory);
+            $fileSystem->mkdir($temporaryDirectory);
             $fileSystem->dumpFile($configFile, $this->getYamlConfig($configName));
         } catch (IOExceptionInterface $e) {
             throw new \Exception($this->trans('commands.config.edit.messages.no-directory').' '.$e->getPath());


### PR DESCRIPTION
Due to the similarity of the English word "temporary" and the Spanish word "temporal" there have been some mixups in the code.