### PR TITLE
[Console] Updated quick start chain to use Drupal 8.0.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - phpunit
   - php box.phar build
   - php drupal.phar --version
-  - php drupal.phar site:new drupal8.dev 8.0.0 --no-interaction
+  - php drupal.phar site:new drupal8.dev 8.0.1 --no-interaction
   - cd drupal8.dev
   - php ../drupal.phar site:install standard --langcode=en --db-type=sqlite --db-file=sites/default/files/.ht.sqlite --site-name="Drupal 8 Site Install" --site-mail=admin@example.com --account-name=admin --account-mail=admin@example.com --account-pass=admin --no-interaction
   - php ../drupal.phar chain --file=$PROJECT_DIR/config/dist/chain/sample.yml

--- a/config/dist/chain/quick-start.yml
+++ b/config/dist/chain/quick-start.yml
@@ -2,7 +2,7 @@ commands:
   - command: site:new
     arguments:
       site-name: drupal8.dev
-      version: 8.0.0
+      version: 8.0.1
   - command: site:install
     options:
         root: /Users/jmolivas/develop/drupal/sites/drupal8.dev


### PR DESCRIPTION
The command ```drupal init --override``` is setting in quick-start chain the Drupal version 8.0.0 when the 8.0.1 is already available 