### PR TITLE
Fixes #1422: Remove the empty hook_theme from generate:module command.

### DIFF
--- a/templates/module/module.twig
+++ b/templates/module/module.twig
@@ -23,12 +23,4 @@ function {{machine_name}}_help($route_name, RouteMatchInterface $route_match) {
   }
 }
 
-/**
- * Implements hook_theme().
- */
-function {{machine_name}}_theme() {
-  $theme = [];
-
-  return $theme;
-}
 {% endblock %}


### PR DESCRIPTION
There is no need to have an empty hook_theme without any functionality when the user generate a module using the command generate:module.