### PR TITLE
Introducing aliases to all commands.

### DIFF
--- a/config/dist/aliases.yml
+++ b/config/dist/aliases.yml
@@ -4,9 +4,270 @@ application:
       cache:
         rebuild:
             - cr
-      themem:
+      theme:
         download:
-            - td
+           - td
       module:
         download:
             - md
+      config:
+        debug:
+          - cde
+      config:
+        edit:
+          - cdit
+      config:
+        export:
+           - ce
+      config:
+        export:
+          content:
+            type:
+              - cect
+      config:
+        export:
+          single:
+            - ces
+      config:
+        export:
+          view:
+            - cev
+      config:
+        import:
+          - ci
+      config:
+        import:
+          single:
+            - cis
+      config:
+        override:
+          - co
+      container:
+        debug:
+          - cod
+      cron:
+        execute:
+          - cre
+      cron:
+        release:
+          - crr
+      dblog:
+        clear:
+          - dbc
+      dblog:
+        debug:
+          - dbb
+      generate:
+        authentication:
+          provider:
+            - gap
+      generate:
+        command:
+          - gcm
+      generate:
+        controller:
+          - gcn
+      generate:
+        doc:
+          - gdc
+      generate:
+        entity:
+          bundle:
+            - geb
+      generate:
+          entity:
+            config:
+                - gecg
+      generate:
+        entity:
+          content:
+              - gect
+      generate:
+        event:
+          subscriber:
+            - ges
+      generate:
+        form:
+          alter:
+            - gfa
+      generate:
+        form:
+          config:
+            - gfc
+      generate:
+        module:
+          - gm
+      generate:
+        permissions:
+          - gp
+      generate:
+        plugin:
+          block:
+            - gpb
+      generate:
+        plugin:
+          condition:
+            - gpc
+      generate:
+        plugin:
+          field:
+            - gpf
+      generate:
+        plugin:
+          fieldformatter:
+            - gpff
+      generate:
+        plugin:
+          fieldtype:
+            - gpft
+      generate:
+        plugin:
+          fieldwidget:
+            - gpfw
+      generate:
+        plugin:
+          imageeffect:
+            - gpie
+      generate:
+        plugin:
+          imageformatter:
+            - gpif
+      generate:
+        plugin:
+          rest:
+            resource:
+              - gprr
+      generate:
+        plugin:
+          rulesaction:
+            - gpra
+      generate:
+        plugin:
+          type:
+            annotation:
+              - gpta
+      generate:
+        plugin:
+          type:
+            yaml:
+              - gpty
+      generate:
+        plugin:
+          views:
+            field:
+                - gpvf
+      generate:
+        service:
+          - gs
+      generate:
+        theme:
+           - gt
+      migrate:
+        debug:
+          - mid
+      migrate:
+        execute:
+          - mie
+      migrate:
+        load:
+          - mil
+      module:
+        debug:
+          - mod
+      module:
+        download:
+          - modo
+      module:
+        install:
+          - moi
+      module:
+        uninstall:
+          - mou
+      rest:
+        debug:
+          - rede
+      rest:
+        disable:
+          - redi
+      rest:
+        enable:
+          - ree
+      router:
+        debug:
+          - rod
+      router:
+        rebuild:
+          - ror
+      site:
+        debug:
+          - sd
+      site:
+        install:
+          - si
+      site:
+        maintenance:
+          - sma
+      site:
+        mode:
+          - smo
+      site:
+        new:
+          - sn
+      site:
+        status:
+          - ss
+      test:
+        debug:
+          - td
+      test:
+        run:
+          - tr
+      update:
+        debug:
+          - upd
+      update:
+        execute:
+          - upe
+      user:
+        login:
+         clear:
+           attempts:
+            - uslca
+      user:
+        login:
+          url:
+          - uslu
+      user:
+        password:
+          hash:
+            - usph
+      user:
+        password:
+          reset:
+            - uspr
+      views:
+        debug:
+          - vde
+      views:
+        disable:
+          - vdi
+      views:
+        enable:
+          - ve
+      yaml:
+        diff:
+          - yd
+      yaml:
+        merge:
+          - ym
+      yaml:
+        split:
+          - ys
+      yaml:
+        update:
+          key:
+            - yu
+      yaml:
+        update:
+          value:
+            - yuv


### PR DESCRIPTION
This is just a start there still some work for this PR to be complete. 

 - We should add the ability of having the command aliases in the drupal list. For instance `drupal cache:build (cr)`. This will make user to easily learn the aliases.
 - We should investigate and how to add a priority, to the aliases over the auto detection of command. 
 - We should test all the commands to make sure that they are running property. 
