### PR TITLE
Fix InvalidArgumentException on config:export:content:type

### DIFF
--- a/src/Command/Config/ExportContentTypeCommand.php
+++ b/src/Command/Config/ExportContentTypeCommand.php
@@ -98,7 +98,7 @@ class ExportContentTypeCommand extends ContainerAwareCommand
         $this->configStorage = $this->getConfigStorage();
 
         $module = $input->getOption('module');
-        $contentType = $input->getArgument('content_type');
+        $contentType = $input->getArgument('content-type');
         $optionalConfig = $input->getOption('optional-config');
 
         $contentTypeDefinition = $this->entity_manager->getDefinition('node_type');


### PR DESCRIPTION
This fixes the InvalidArgumentException: „The "content_type" argument
does not exist.“ I have not looked at the whole code and just tried
this out.