### PR TITLE
Removing extra space causing yml parsing error

### DIFF
--- a/templates/module/links.menu-entity-config.yml.twig
+++ b/templates/module/links.menu-entity-config.yml.twig
@@ -4,5 +4,5 @@ entity.{{ entity_name }}.collection:
   route_name: entity.{{ entity_name }}.collection
   description: 'List {{ label }} (bundles)'
   parent: system.admin_structure
-   weight: 99
+  weight: 99
 


### PR DESCRIPTION
Menu's for content and bundle entities were not showing their menu items in admin/structure