### PR TITLE
Another extraneous space removal

### DIFF
--- a/templates/module/links.menu-entity-content.yml.twig
+++ b/templates/module/links.menu-entity-content.yml.twig
@@ -4,7 +4,7 @@ entity.{{ entity_name }}.collection:
   route_name: entity.{{ entity_name }}.collection
   description: 'List {{ label }} entities'
   parent: system.admin_structure
-   weight: 100
+  weight: 100
 
 {# Note: a content entity with bundles will have the settings configured on the bundle (config) entity. #}
 {% if not bundle_entity_type %}


### PR DESCRIPTION
Menu's for content and bundle entities were not showing their menu items in admin/structure