### PR TITLE
[generate:form] Use ElementInfoManager to define all input types available

### DIFF
--- a/src/Command/FormTrait.php
+++ b/src/Command/FormTrait.php
@@ -22,7 +22,9 @@ trait FormTrait
             $this->trans('commands.common.questions.inputs.confirm'),
             true
         )) {
-            $input_types = array();
+            $input_types = [
+                'fieldset',
+            ];
             $elementInfoManager = \Drupal::service('plugin.manager.element_info');
             foreach ($elementInfoManager->getDefinitions() as $definition) {
                 $type = $definition['id'];
@@ -33,6 +35,7 @@ trait FormTrait
                     }
                 }
             }
+            sort($input_types);
 
             $inputs = [];
             $fieldSets = [];

--- a/src/Command/FormTrait.php
+++ b/src/Command/FormTrait.php
@@ -22,24 +22,17 @@ trait FormTrait
             $this->trans('commands.common.questions.inputs.confirm'),
             true
         )) {
-            $input_types = [
-              'color',
-              'checkbox',
-              'checkboxes',
-              'date',
-              'datetime',
-              'fieldset',
-              'email',
-              'number',
-              'password',
-              'password_confirm',
-              'range',
-              'radios',
-              'select',
-              'tel',
-              'textarea',
-              'textfield',
-            ];
+            $input_types = array();
+            $elementInfoManager = \Drupal::service('plugin.manager.element_info');
+            foreach ($elementInfoManager->getDefinitions() as $definition) {
+                $type = $definition['id'];
+                $elementInfo = $elementInfoManager->getInfo($type);
+                if (isset($elementInfo['#input']) && $elementInfo['#input']) {
+                    if (!in_array($type, $input_types)) {
+                        $input_types[] = $type;
+                    }
+                }
+            }
 
             $inputs = [];
             $fieldSets = [];


### PR DESCRIPTION
With this, the console can autocomplete all input types available on the site