### PR TITLE
[generate:entity:content] Clear cache after creating a new bundle

### DIFF
--- a/templates/module/src/Entity/entity.php.twig
+++ b/templates/module/src/Entity/entity.php.twig
@@ -9,7 +9,7 @@ namespace Drupal\{{ module }}\Entity;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
 use Drupal\{{ module }}\{{ entity_class }}Interface;
 {% endblock %}
 
@@ -46,7 +46,7 @@ use Drupal\{{ module }}\{{ entity_class }}Interface;
  *   }
  * )
  */
-class {{ entity_class }} extends ConfigEntityBase implements {{ entity_class }}Interface {% endblock %}
+class {{ entity_class }} extends ConfigEntityBundleBase implements {{ entity_class }}Interface {% endblock %}
 {% block class_methods %}
   /**
    * The {{ label }} ID.


### PR DESCRIPTION
When I create a new bundle and then I create a new entity with this, an exception appear:
```
Drupal\Component\Plugin\Exception\PluginNotFoundException: The "entity:name_entity:new_bundle" plugin does not exist
```
This is because after creating a new bundle, the cache is not cleared.
To fix this we can use ConfigEntityBundleBase.
