### PR TITLE
Fix Unable to filter with a CSS selector as the Symfony CssSelector exception

### DIFF
--- a/src/Command/Module/DownloadCommand.php
+++ b/src/Command/Module/DownloadCommand.php
@@ -67,7 +67,7 @@ class DownloadCommand extends Command
 
             $crawler = new Crawler($html);
             $releases = [];
-            foreach ($crawler->filter('span.file a') as $element) {
+            foreach ($crawler->filterXPath('.//*/div[2]/div[2]/div/table/tbody/tr[1]/td[1]/span[@class=\'file\']/a') as $element) {
                 if (strpos($element->nodeValue, '.tar.gz') > 0) {
                     $release_name = str_replace(
                         '.tar.gz',


### PR DESCRIPTION
This PR uses `filterXPath` as exception suggested, on `module:download` command
![screen shot 2015-12-23 at 12 41 37 pm](https://cloud.githubusercontent.com/assets/1909779/11983895/afa4b098-a97c-11e5-8c8e-10881ca7b3bf.png)
