### PR TITLE
Fix the core version validation in generate:module

### DIFF
--- a/config/translations/en/generate.module.yml
+++ b/config/translations/en/generate.module.yml
@@ -28,4 +28,5 @@ questions:
 warnings:
     module-unavailable: 'Warning The following modules are not already available in your local environment "%s"'
 errors:
+    invalid-core: 'The core version "%s" is invalid.'
     directory-exists: 'The target directory "%s" is not empty.'

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -282,7 +282,8 @@ class ModuleCommand extends GeneratorCommand
             $core = $output->ask(
                 $this->trans('commands.generate.module.questions.core'), '8.x',
                 function ($core) {
-                    if (!preg_match('/^[0-9]+\.x$/', $core)) {
+                    // Only allow 8.x and higher as core version.
+                    if (!preg_match('/^([0-9]+)\.x$/', $core, $matches) || ($matches[1] < 8)) {
                         throw new \InvalidArgumentException(
                             sprintf(
                                 $this->trans('commands.generate.module.errors.invalid-core'),

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -281,7 +281,18 @@ class ModuleCommand extends GeneratorCommand
         if (!$core) {
             $core = $output->ask(
                 $this->trans('commands.generate.module.questions.core'), '8.x',
-                '8.x'
+                function ($core) {
+                    if (!preg_match('/^[0-9]+\.x$/', $core)) {
+                        throw new \InvalidArgumentException(
+                            sprintf(
+                                $this->trans('commands.generate.module.errors.invalid-core'),
+                                $core
+                            )
+                        );
+                    }
+
+                    return $core;
+                }
             );
         }
         $input->setOption('core', $core);


### PR DESCRIPTION
Currently when running `generate:module` you get a called to undefined function `8.x` because there is an incorrect parameter that is being passed to the Symfony question helper. I implemented some basic validation of the core property.