### PR TITLE
Use ContentEntityDeleteForm as a base class for content entity delete forms

### DIFF
--- a/templates/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-delete.php.twig
@@ -10,8 +10,6 @@ namespace Drupal\{{module}}\Form;
 
 {% block use_class %}
 use Drupal\Core\Entity\ContentEntityDeleteForm;
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 {% endblock %}
 
 {% block class_declaration %}

--- a/templates/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-delete.php.twig
@@ -9,7 +9,7 @@ namespace Drupal\{{module}}\Form;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Core\Entity\ContentEntityConfirmFormBase;
+use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 {% endblock %}
@@ -20,44 +20,4 @@ use Drupal\Core\Url;
  *
  * @ingroup {{module}}
  */
-class {{ entity_class }}DeleteForm extends ContentEntityConfirmFormBase {% endblock %}
-{% block class_methods %}
-  /**
-   * {@inheritdoc}
-   */
-  public function getQuestion() {
-    return $this->t('Are you sure you want to delete entity %name?', array('%name' => $this->entity->label()));
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCancelUrl() {
-    return new Url('entity.{{ entity_name }}.collection');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getConfirmText() {
-    return $this->t('Delete');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->entity->delete();
-
-    drupal_set_message(
-      $this->t('content @type: deleted @label.',
-        [
-          '@type' => $this->entity->bundle(),
-          '@label' => $this->entity->label()
-        ]
-        )
-    );
-
-    $form_state->setRedirectUrl($this->getCancelUrl());
-  }
-{% endblock %}
+class {{ entity_class }}DeleteForm extends ContentEntityDeleteForm {% endblock %}


### PR DESCRIPTION
Currently `ContentEntityConfirmFormBase` is being used but `ContentEntityDeleteForm` already provides the delete-specific information.

It is in fact superior to the current delete template because it properly handles entity translations.

I don't know if there is much of a use-case of overriding the delete form (i.e. I usually just reference `ContentEntityDeleteForm` in the entity annotation directly), but I went for the minimally invasive change for now.