### PR TITLE
Use the language_select widget instead of a custom form element for content entities

### DIFF
--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -11,7 +11,6 @@ namespace Drupal\{{module}}\Form;
 {% block use_class %}
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Language\Language;
 {% endblock %}
 
 {% block class_declaration %}
@@ -30,24 +29,7 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
     $form = parent::buildForm($form, $form_state);
     $entity = $this->entity;
 
-    $form['langcode'] = array(
-      '#title' => $this->t('Language'),
-      '#type' => 'language_select',
-      '#default_value' => $entity->langcode->value,
-      '#languages' => Language::STATE_ALL,
-    );
-
     return $form;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submit(array $form, FormStateInterface $form_state) {
-    // Build the entity object from the submitted values.
-    $entity = parent::submit($form, $form_state);
-
-    return $entity;
   }
 
   /**
@@ -55,7 +37,7 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
    */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
-    $status = $entity->save();
+    $status = parent::save($form, $form_state);
 
     switch ($status) {
       case SAVED_NEW:

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -250,7 +250,12 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
 
     $fields['langcode'] = BaseFieldDefinition::create('language')
       ->setLabel(t('Language code'))
-      ->setDescription(t('The language code for the {{ label }} entity.'));
+      ->setDescription(t('The language code for the {{ label }} entity.'))
+      ->setDisplayOptions('form', array(
+        'type' => 'language_select',
+        'weight' => 10,
+      ))
+      ->setDisplayConfigurable('form', TRUE);
 
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))


### PR DESCRIPTION
It's preferable to use the widget so people can override this properly from the UI.

I am not sure if we want to leave in the empty `buildForm()` for people or not, but left it in for now.

Also removed the `submit()` method from the form as that is obsolete and no longer being called anyway.

And used `parent::save()` instead of calling `$this->entity->save()` manually.