### PR TITLE
[generate:plugin:fieldformatter] and [generate:plugin:fieldtype] 

### DIFF
--- a/src/Command/Generate/PluginFieldFormatterCommand.php
+++ b/src/Command/Generate/PluginFieldFormatterCommand.php
@@ -10,6 +10,7 @@ namespace Drupal\Console\Command\Generate;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Drupal\Console\Generator\PluginFieldFormatterGenerator;
 use Drupal\Console\Command\ModuleTrait;
 use Drupal\Console\Command\ConfirmationTrait;
@@ -59,10 +60,10 @@ class PluginFieldFormatterCommand extends GeneratorCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new DrupalStyle($input, $output);
+        $io = new DrupalStyle($input, $output);
 
         // @see use Drupal\Console\Command\ConfirmationTrait::confirmGeneration
-        if (!$this->confirmGeneration($output)) {
+        if (!$this->confirmGeneration($io)) {
             return;
         }
 
@@ -81,7 +82,8 @@ class PluginFieldFormatterCommand extends GeneratorCommand
 
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $output = new DrupalStyle($input, $output);
+        $io = new DrupalStyle($input, $output);
+        $fieldTypePluginManager = $this->hasGetService('plugin.manager.field.field_type');
 
         // --module option
         $module = $input->getOption('module');
@@ -94,7 +96,7 @@ class PluginFieldFormatterCommand extends GeneratorCommand
         // --class option
         $class = $input->getOption('class');
         if (!$class) {
-            $class = $output->ask(
+            $class = $io->ask(
                 $this->trans('commands.generate.plugin.fieldformatter.questions.class'),
                 'ExampleFieldFormatter'
             );
@@ -104,7 +106,7 @@ class PluginFieldFormatterCommand extends GeneratorCommand
         // --plugin label option
         $label = $input->getOption('label');
         if (!$label) {
-            $label = $output->ask(
+            $label = $io->ask(
                 $this->trans('commands.generate.plugin.fieldformatter.questions.label'),
                 $this->getStringHelper()->camelCaseToHuman($class)
             );
@@ -114,7 +116,7 @@ class PluginFieldFormatterCommand extends GeneratorCommand
         // --name option
         $plugin_id = $input->getOption('plugin-id');
         if (!$plugin_id) {
-            $plugin_id = $output->ask(
+            $plugin_id = $io->ask(
                 $this->trans('commands.generate.plugin.fieldformatter.questions.plugin-id'),
                 $this->getStringHelper()->camelCaseToUnderscore($class)
             );
@@ -124,9 +126,23 @@ class PluginFieldFormatterCommand extends GeneratorCommand
         // --field type option
         $field_type = $input->getOption('field-type');
         if (!$field_type) {
-            $field_type = $output->ask(
-                $this->trans('commands.generate.plugin.fieldformatter.questions.field-type')
+            // Gather valid field types.
+            $field_type_options = array();
+            foreach ($fieldTypePluginManager->getGroupedDefinitions($fieldTypePluginManager->getUiDefinitions()) as $category => $field_types) {
+                foreach ($field_types as $name => $field_type) {
+                    $field_type_options[] = $name;
+                }
+            }
+
+            $questionHelper = $this->getQuestionHelper();
+
+            $question = new ChoiceQuestion(
+                $this->trans('commands.generate.plugin.fieldwidget.questions.field-type'),
+                $field_type_options,
+                0
             );
+
+            $field_type = $questionHelper->ask($input, $output, $question);
             $input->setOption('field-type', $field_type);
         }
     }

--- a/templates/module/src/Plugin/Field/FieldType/fieldtype.php.twig
+++ b/templates/module/src/Plugin/Field/FieldType/fieldtype.php.twig
@@ -31,16 +31,10 @@ use Drupal\Core\TypedData\DataDefinition;
  *   default_widget = "{{ default_widget }}"{% if default_widget and default_formatter %},
 {% endif %}
 {% else %}
-
- *   Create and/or assign a default_widget.
- *   ex. default_widget = "field_widget"
 {% endif %}
 {%  if default_formatter %}
  *   default_formatter = "{{ default_formatter }}"
 {% else %}
-
- *   Create and/or assign a default_formatter.
- *   ex. default_formatter = "field_formatter"
 {%  endif %}
  * )
  */


### PR DESCRIPTION
[generate:plugin:fieldformatter] Fixed Drupal style implementation   
[generate:plugin:fieldtype] Fixed Template output, the annotation commend cause an error parsing all field types