### PR TITLE
[config:export:content:type] Fixed issue #1663

### DIFF
--- a/src/Command/Config/ExportContentTypeCommand.php
+++ b/src/Command/Config/ExportContentTypeCommand.php
@@ -69,7 +69,7 @@ class ExportContentTypeCommand extends ContainerAwareCommand
             $bundles_entities = $entity_manager->getStorage('node_type')->loadMultiple();
             $bundles = array();
             foreach ($bundles_entities as $entity) {
-                $bundles[] = $entity->label();
+                $bundles[$entity->id()] = $entity->label();
             }
 
             $contentType = $io->choice(

--- a/src/Command/Config/ExportTrait.php
+++ b/src/Command/Config/ExportTrait.php
@@ -60,23 +60,13 @@ trait ExportTrait
 
             $io->info('- ' . $configFile);
 
-            $configDirectory = sprintf(
-                '%s/%s',
-                $this->getKernelHelper()->getSitePath(),
-                $configDirectory
-            );
-
             // Create directory if doesn't exist
             if (!file_exists($configDirectory)) {
                 mkdir($configDirectory, 0755, true);
             }
 
             file_put_contents(
-                sprintf(
-                    '%s/%s',
-                    $this->getKernelHelper()->getSitePath(),
-                    $configFile
-                ),
+                $configFile,
                 $yamlConfig
             );
         }


### PR DESCRIPTION
The config of the content type needs the id of the content type and not the label. 
It is also trying to create the file on another path that is not valid.

Also this fix the [config:export:view] command.