### PR TITLE
[console] Make DrupalExtensionDiscovery::reset() static

### DIFF
--- a/src/Utils/DrupalExtensionDiscovery.php
+++ b/src/Utils/DrupalExtensionDiscovery.php
@@ -14,7 +14,7 @@ class DrupalExtensionDiscovery extends ExtensionDiscovery
     /**
      * Reset internal static cache.
      */
-    public function reset()
+    public static function reset()
     {
         static::$files = array();
     }


### PR DESCRIPTION
A site with the patch for https://www.drupal.org/node/2156401 applied throws an error, since it defines ExtensionDiscovery::reset() as a static function.