### PR TITLE
[helper] Support alternate SSH port during login.

### DIFF
--- a/src/Helper/RemoteHelper.php
+++ b/src/Helper/RemoteHelper.php
@@ -57,7 +57,7 @@ class RemoteHelper extends Helper
             return $this->getTranslator()->trans('commands.site.debug.messages.private-key');
         }
 
-        $ssh = new SSH2($targetConfig['host']);
+        $ssh = new SSH2($targetConfig['host'], $targetConfig['port']);
         if (!$ssh->login('root', $key)) {
             return $this->getTranslator()->trans('commands.site.debug.messages.error-connect');
         } else {


### PR DESCRIPTION
I am running Drupal in a Docker container with the SSH port forwarded to `2222`. I had to apply this patch to get remote Drush Console to connect successfully.