### PR TITLE
Show the entity page rather than the edit form after editing an entity.

### DIFF
--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -51,6 +51,6 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
           '%label' => $entity->label(),
         ]));
     }
-    $form_state->setRedirect('entity.{{ entity_name }}.edit_form', ['{{ entity_name }}' => $entity->id()]);
+    $form_state->setRedirect('entity.{{ entity_name }}.canonical', ['{{ entity_name }}' => $entity->id()]);
   }
 {% endblock %}


### PR DESCRIPTION
When an entity that is generated with `console generate:entity:content` is edited, the user remains on the edit form after submitting the form. This is unexpected and gives the impression to the user that the submission of the form was unsuccessful, even though a success message is shown.

The standard practice in Drupal is that a user is redirected to the full page view of the entity, let's follow this practice for the content entities we generate.

This was reported by @idimopoulos as part of a usability test for the Joinup project of the European Commission.