### PR TITLE
Default to neutral for entity access

### DIFF
--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -42,7 +42,8 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
         return AccessResult::allowedIfHasPermission($account, 'delete {{ label|lower }} entities');
     }
 
-    return AccessResult::allowed();
+    // Unknown operation, no opinion.
+    return AccessResult::neutral();
   }
 
   /**


### PR DESCRIPTION
Currently the code generated for a content entity's access handler always blindly allows access for unknown operations. This is a potential security risk as it might unintentionally disclose information when a new entity operation is implemented in the future.

It would be better to default to `AccessResult::neutral()` instead of `AccessResult::allowed()`. After all, if we do not know what the operation is doing we cannot allow nor deny. This is consistent with how it is implemented in core, see for example `EntityAccessControlHandler::checkAccess()`.

This was reported by @idimopoulos as part of a code review for the Joinup project of the European Commission.