### PR TITLE
[about] Improve output to render current drupal version

### DIFF
--- a/config/translations/ca/site.status.yml
+++ b/config/translations/ca/site.status.yml
@@ -19,3 +19,5 @@ messages:
     directory_temporary: 'Site temporary directory'
     directory_theme_default: 'Default theme directory'
     directory_theme_admin: 'Admin theme directory'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'

--- a/config/translations/en/site.status.yml
+++ b/config/translations/en/site.status.yml
@@ -19,3 +19,5 @@ messages:
     directory_temporary: 'Site temporary directory'
     directory_theme_default: 'Default theme directory'
     directory_theme_admin: 'Admin theme directory'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'

--- a/config/translations/es/site.status.yml
+++ b/config/translations/es/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'Directorio temporal del sitio'
     directory_theme_default: 'Directorio del tema por defecto'
     directory_theme_admin: 'Directorio del tema de administración'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: Configuration
     active: 'Ruta de la configuración activa'
     staging: 'Ruta de la configuración de staging'

--- a/config/translations/fr/site.status.yml
+++ b/config/translations/fr/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'Site temporary directory'
     directory_theme_default: 'Default theme directory'
     directory_theme_admin: 'Admin theme directory'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: Configuration
     active: 'Active config path'
     staging: 'Staging config path'

--- a/config/translations/hi/site.status.yml
+++ b/config/translations/hi/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'साइट अस्थायी डायरेक्टरी'
     directory_theme_default: 'डीफाल्ट थीम directory'
     directory_theme_admin: 'प्रबंधक थीम directory'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: Configuration
     active: 'सक्रिय समाकृति का पथ'
     staging: 'स्टेजिंग समाकृति का पथ'

--- a/config/translations/hu/site.status.yml
+++ b/config/translations/hu/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'Oldal ideiglenes könyvtára'
     directory_theme_default: 'Alapértelmezett smink könyvtár'
     directory_theme_admin: 'Admin smink könyvtár'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: Configuration
     active: 'Active config path'
     staging: 'Staging config path'

--- a/config/translations/ja/site.status.yml
+++ b/config/translations/ja/site.status.yml
@@ -19,3 +19,5 @@ messages:
     directory_temporary: 'Site temporary directory'
     directory_theme_default: 'Default theme directory'
     directory_theme_admin: 'Admin theme directory'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'

--- a/config/translations/pt_br/site.status.yml
+++ b/config/translations/pt_br/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'Diretório de arquivos temporários'
     directory_theme_default: 'Diretório do tema padrão'
     directory_theme_admin: 'Diretório do tema administrativo'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: Configuração
     active: 'Diretório da configuração ativa'
     staging: 'Diretório da configuração de Staging (Ambiente de teste)'

--- a/config/translations/ro/site.status.yml
+++ b/config/translations/ro/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'Directorul temporar al saitului'
     directory_theme_default: 'Directorul temei implicite'
     directory_theme_admin: 'Directorul temei de administrare'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: Configurare
     active: 'Calea către configurarile active'
     staging: 'Calea către configurările în aşteptare'

--- a/config/translations/ru/site.status.yml
+++ b/config/translations/ru/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'Site temporary directory'
     directory_theme_default: 'Default theme directory'
     directory_theme_admin: 'Admin theme directory'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: Configuration
     active: 'Active config path'
     staging: 'Staging config path'

--- a/config/translations/vn/site.status.yml
+++ b/config/translations/vn/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 'Thư mục lưu trữ tạm thời'
     directory_theme_default: 'Thư mục lưu phần hiển thị mặc định'
     directory_theme_admin: 'Thư mục lưu phần hiển thị quản trị'
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: 'Phần thiết lập'
     active: 'Đường dẫn cho phần thiết lập bản hoạt động'
     staging: 'Đường dẫn cho phần thiết lập bản thử nghiệm'

--- a/config/translations/zh_hans/site.status.yml
+++ b/config/translations/zh_hans/site.status.yml
@@ -19,6 +19,8 @@ messages:
     directory_temporary: 网站临时目录
     directory_theme_default: 网站主题目录
     directory_theme_admin: 管理员主题目录
+    current_version: 'Current Drupal version (%s)'
+    not_installed: 'Drupal is not installed'
     configuration: '配置'
     active: '有效配置路径'
     staging: '中间站（Staging）配置路径'

--- a/src/Application.php
+++ b/src/Application.php
@@ -33,7 +33,7 @@ class Application extends BaseApplication
     /**
      * @var string
      */
-    const DRUPAL_VERSION = '8.0.2';
+    const DRUPAL_SUPPORTED_VERSION = '8.0.2';
     /**
      * @var \Drupal\Console\Config
      */

--- a/src/Command/AboutCommand.php
+++ b/src/Command/AboutCommand.php
@@ -36,11 +36,24 @@ class AboutCommand extends Command
 
         $application = $this->getApplication();
 
+        $drupal = $this->getDrupalHelper();
+
+        // Provide drupal version if it's installed
+        $drupalVersion = $this->trans('commands.site.status.messages.not_installed');
+        if($drupal->isInstalled()) {
+
+            $drupalVersion = sprintf(
+                $this->trans('commands.site.status.messages.current_version'),
+                $this->getSite()->getDrupalVersion()
+            );
+        }
+
         $aboutTitle = sprintf(
-            '%s (%s) | Supports Drupal %s',
+            '%s (%s) | Supports Drupal (%s) | %s',
             $this->trans('commands.site.status.messages.console'),
             $application->getVersion(),
-            $application::DRUPAL_VERSION
+            $application::DRUPAL_SUPPORTED_VERSION,
+            $drupalVersion
         );
 
         $io->setDecorated(false);
@@ -60,7 +73,7 @@ class AboutCommand extends Command
                 $this->trans('commands.site.new.description'),
                 sprintf(
                     'drupal site:new drupal8.dev %s',
-                    $application::DRUPAL_VERSION
+                    $application::DRUPAL_SUPPORTED_VERSION
                 )
             ],
             'site-install' => [

--- a/src/Helper/SiteHelper.php
+++ b/src/Helper/SiteHelper.php
@@ -411,4 +411,14 @@ class SiteHelper extends Helper
     {
         return 'site';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDrupalVersion()
+    {
+        $projects = \Drupal::service('update.manager')->getProjects();
+
+        return $projects['drupal']['info']['version'];
+    }
 }

--- a/src/Helper/SiteHelper.php
+++ b/src/Helper/SiteHelper.php
@@ -417,7 +417,7 @@ class SiteHelper extends Helper
      */
     public function getDrupalVersion()
     {
-        $projects = \Drupal::service('update.manager')->getProjects();
+        $projects = $this->getDrupalApi()->getService('update.manager')->getProjects();
 
         return $projects['drupal']['info']['version'];
     }


### PR DESCRIPTION
Added logic to print current drupal version if is available.

Check an example if drupal is detected
<img width="777" alt="drupal_version" src="https://cloud.githubusercontent.com/assets/907914/12454970/529a2308-bf5f-11e5-9f47-73936a11960d.png">

Check an example if drupal is not detected.
<img width="700" alt="drupal_version_not_available" src="https://cloud.githubusercontent.com/assets/907914/12454988/5e1438cc-bf5f-11e5-9294-bd3e56dd32b1.png">
