### PR TITLE
Plugin managers generated in root namespace

### DIFF
--- a/templates/module/plugin-yaml-services.yml.twig
+++ b/templates/module/plugin-yaml-services.yml.twig
@@ -2,5 +2,5 @@
 services:
 {% endif %}
   plugin.manager.{{ plugin_name | lower }}:
-    class: Drupal\{{ module }}\Plugin\{{ plugin_class }}Manager
+    class: Drupal\{{ module }}\{{ plugin_class }}Manager
     arguments: ['@module_handler', '@cache.discovery']


### PR DESCRIPTION
When running YAML plugin generator, the manager and manager interface are in ````\Drupal\{{ module }}```` not the Plugin namespace.

See location of https://github.com/hechoendrupal/DrupalConsole/blob/master/templates/module/src/yaml-plugin-manager-interface.php.twig