### PR TITLE
[generate:entity:content] Fixed route provider template #1739

### DIFF
--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -143,6 +143,17 @@ class EntityContentGenerator extends Generator
 
             // Check for hook_theme() in module file and warn ...
             $module_filename = $this->getSite()->getModulePath($module).'/'.$module.'.module';
+            // Check if the module file exists.
+            if (!file_exists($module_filename)) {
+                $this->renderFile(
+                    'module/module.twig',
+                    $this->getSite()->getModulePath($module).'/'.$module . '.module',
+                    [
+                        'machine_name' => $module,
+                        'description' => '',
+                    ]
+                );
+            }
             $module_file_contents = file_get_contents($module_filename);
             if (strpos($module_file_contents, 'function ' . $module . '_theme') !== false) {
                 echo "================\nWarning:\n================\n" .

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -68,7 +68,11 @@ use Drupal\user\UserInterface;
 {% endif %}
  *   links = {
  *     "canonical" = "/admin/structure/{{ entity_name }}/{{ '{'~entity_name~'}' }}",
+{% if bundle_entity_type %}
+ *     "add-form" = "/admin/structure/{{ entity_name }}/add/{{ '{'~bundle_entity_type~'}' }}",
+{% else %}
  *     "add-form" = "/admin/structure/{{ entity_name }}/add",
+{% endif %}
  *     "edit-form" = "/admin/structure/{{ entity_name }}/{{ '{'~entity_name~'}' }}/edit",
  *     "delete-form" = "/admin/structure/{{ entity_name }}/{{ '{'~entity_name~'}' }}/delete",
  *     "collection" = "/admin/structure/{{ entity_name }}",

--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -38,8 +38,8 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
     if ($add_form_route = $this->getAddFormRoute($entity_type)) {
       $collection->add("entity.{$entity_type_id}.add_form", $add_form_route);
     }
-
 {% if bundle_entity_type %}
+
     $add_page_route = $this->getAddPageRoute($entity_type);
     $collection->add("$entity_type_id.add_page", $add_page_route);
 {% endif %}

--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -162,7 +162,7 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
       $route = new Route("/admin/structure/{$entity_type->id()}/settings");
       $route
         ->setDefaults([
-          '_form' => 'Drupal\{{ module }}\Controller\{{ entity_class }}SettingsForm',
+          '_form' => 'Drupal\{{ module }}\Form\{{ entity_class }}SettingsForm',
           '_title' => "{$entity_type->getLabel()} settings",
         ])
         ->setRequirement('_permission', $entity_type->getAdminPermission())

--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -39,9 +39,10 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
       $collection->add("entity.{$entity_type_id}.add_form", $add_form_route);
     }
 
-    if ($add_page_route = $this->getAddPageRoute($entity_type)) {
-      $collection->add("$entity_type_id.add_page", $add_page_route);
-    }
+{% if bundle_entity_type %}
+    $add_page_route = $this->getAddPageRoute($entity_type);
+    $collection->add("$entity_type_id.add_page", $add_page_route);
+{% endif %}
 
     if ($settings_form_route = $this->getSettingsFormRoute($entity_type)) {
       $collection->add("$entity_type_id.settings", $settings_form_route);
@@ -92,29 +93,30 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
       ];
 
       $route = new Route($entity_type->getLinkTemplate('add-form'));
+{% if bundle_entity_type %}
+      $bundle_entity_type_id = $entity_type->getBundleEntityType();
       // Content entities with bundles are added via a dedicated controller.
-      if ($bundle_entity_type_id = $entity_type->getBundleEntityType()) {
-        $route
-          ->setDefaults([
-            '_controller' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::addForm',
-            '_title_callback' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::getAddFormTitle',
-          ])
-          ->setRequirement('_entity_create_access', $entity_type_id . ':{' . $bundle_entity_type_id . '}');
-        $parameters[$bundle_entity_type_id] = ['type' => 'entity:' . $bundle_entity_type_id];
+      $route
+        ->setDefaults([
+          '_controller' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::addForm',
+          '_title_callback' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::getAddFormTitle',
+        ])
+        ->setRequirement('_entity_create_access', $entity_type_id . ':{' . $bundle_entity_type_id . '}');
+      $parameters[$bundle_entity_type_id] = ['type' => 'entity:' . $bundle_entity_type_id];
+{% else %}
+      // Use the add form handler, if available, otherwise default.
+      $operation = 'default';
+      if ($entity_type->getFormClass('add')) {
+        $operation = 'add';
       }
-      else {
-        // Use the add form handler, if available, otherwise default.
-        $operation = 'default';
-        if ($entity_type->getFormClass('add')) {
-          $operation = 'add';
-        }
-        $route
-          ->setDefaults([
-            '_entity_form' => "{$entity_type_id}.{$operation}",
-            '_title' => "Add {$entity_type->getLabel()}",
-          ])
-          ->setRequirement('_entity_create_access', $entity_type_id);
-      }
+      $route
+        ->setDefaults([
+          '_entity_form' => "{$entity_type_id}.{$operation}",
+          '_title' => "Add {$entity_type->getLabel()}",
+        ])
+        ->setRequirement('_entity_create_access', $entity_type_id);
+{% endif %}
+
       $route
         ->setOption('parameters', $parameters)
         ->setOption('_admin_route', TRUE);
@@ -122,6 +124,7 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
       return $route;
     }
   }
+{% if bundle_entity_type %}
 
   /**
    * Gets the add page route.
@@ -133,19 +136,18 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
    *   The generated route, if available.
    */
   protected function getAddPageRoute(EntityTypeInterface $entity_type) {
-    if ($entity_type->getBundleEntityType()) {
-      $route = new Route("/admin/structure/{$entity_type->id()}/add");
-      $route
-        ->setDefaults([
-          '_controller' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::add',
-          '_title' => "Add {$entity_type->getLabel()}",
-        ])
-        ->setRequirement('_entity_create_access', $entity_type->id())
-        ->setOption('_admin_route', TRUE);
+    $route = new Route("/admin/structure/{$entity_type->id()}/add");
+    $route
+      ->setDefaults([
+        '_controller' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::add',
+        '_title' => "Add {$entity_type->getLabel()}",
+      ])
+      ->setRequirement('_entity_create_access', $entity_type->id())
+      ->setOption('_admin_route', TRUE);
 
-      return $route;
-    }
+    return $route;
   }
+{% endif %}
 
   /**
    * Gets the settings form route.

--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -94,6 +94,7 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
       $route = new Route($entity_type->getLinkTemplate('add-form'));
       // Content entities with bundles are added via a dedicated controller.
       if ($bundle_entity_type_id = $entity_type->getBundleEntityType()) {
+        $route = new Route($entity_type->getLinkTemplate('add-form') . '/{' . $bundle_entity_type_id . '}');
         $route
           ->setDefaults([
             '_controller' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::addForm',

--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -94,7 +94,6 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
       $route = new Route($entity_type->getLinkTemplate('add-form'));
       // Content entities with bundles are added via a dedicated controller.
       if ($bundle_entity_type_id = $entity_type->getBundleEntityType()) {
-        $route = new Route($entity_type->getLinkTemplate('add-form') . '/{' . $bundle_entity_type_id . '}');
         $route
           ->setDefaults([
             '_controller' => 'Drupal\{{ module }}\Controller\{{ entity_class }}AddController::addForm',


### PR DESCRIPTION
- This pull fix the issue #1739
- Also it set the setting form properly
- As now the [generate:module] command may not load the .module file, this command needs to detect this and then to create it if the entity has bundle.