### PR TITLE
[config:export:single] Add include dependencies option

### DIFF
--- a/config/translations/en/config.export.single.yml
+++ b/config/translations/en/config.export.single.yml
@@ -2,6 +2,7 @@ description: 'Export single configuration as yml file.'
 arguments:
     config-name: 'Configuration name.'
 options:
+    include-dependencies: 'Export dependencies of the configuration as well.'
     simple-configuration: 'Simple configuration'
 questions:
     config-type: 'Configuration type'

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -202,6 +202,8 @@ class ExportSingleCommand extends ContainerAwareCommand
     }
 
     /**
+     * Returns all configuration depedencies for a configuration item.
+     *
      * @param string $configName
      *   The name of the configuration item to get dependencies for.
      *

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -177,21 +177,57 @@ class ExportSingleCommand extends ContainerAwareCommand
 
         $configName = $input->getArgument('config-name');
 
-        $configExportFile = $directory . '/' . $configName.'.yml';
+        $configNames = [$configName];
+        if ($input->getOption('include-dependencies')) {
+            $configNames += $this->getConfigDependencies($configName);
+        }
+        foreach ($configNames as $configName) {
+            $config = $this->getConfigFactory()->getEditable($configName);
 
-        file_unmanaged_delete($configExportFile);
+            $configExportFile = $directory . '/' . $configName.'.yml';
 
-        $config = $this->getConfigFactory()->getEditable($configName);
+            file_unmanaged_delete($configExportFile);
 
-        if ($config) {
-            $yaml = Yaml::encode($config->getRawData());
-            // Save release file
-            file_put_contents($configExportFile, $yaml);
-            $io->info(
-                sprintf($this->trans('commands.config.export.single.messages.export'), $configExportFile)
-            );
-        } else {
-            $io->error($this->trans('commands.config.export.single.messages.config-not-found'));
+            if ($config) {
+                $yaml = Yaml::encode($config->getRawData());
+                // Save configuration file.
+                file_put_contents($configExportFile, $yaml);
+                $io->info(
+                  sprintf($this->trans('commands.config.export.single.messages.export'), $configExportFile)
+                );
+            } else {
+                $io->error($this->trans('commands.config.export.single.messages.config-not-found'));
+            }
         }
     }
+
+    /**
+     * @param string $configName
+     *   The name of the configuration item to get dependencies for.
+     *
+     * @return array
+     *   An array of dependent configuration item names.
+     */
+    protected function getConfigDependencies($configName) {
+        $dependencyManager = $this->getConfigManager()->getConfigDependencyManager();
+        // Compute dependent config.
+        $dependent_list = $dependencyManager->getDependentEntities('config', $configName);
+        $dependents = [];
+        foreach ($dependent_list as $config_name => $item) {
+            if (!isset($dependents[$config_name])) {
+                $dependents[$config_name] = $config_name;
+            }
+            // Grab any dependent graph paths.
+            if (isset($item['reverse_paths'])) {
+                foreach ($item['reverse_paths'] as $dependent_name => $value) {
+                    if ($value && !isset($dependents[$dependent_name])) {
+                        $dependents[$dependent_name] = $dependent_name;
+                    }
+                }
+            }
+        }
+
+        return $dependents;
+    }
+
 }

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -50,6 +50,12 @@ class ExportSingleCommand extends ContainerAwareCommand
                 '',
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.config.export.arguments.directory')
+            )
+            ->addOption(
+                'include-dependencies',
+                '',
+                InputOption::VALUE_NONE,
+                $this->trans('commands.config.export.single.options.include-dependencies')
             );
     }
 

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -17,9 +17,21 @@ use Drupal\Console\Command\ContainerAwareCommand;
 
 class ExportSingleCommand extends ContainerAwareCommand
 {
+    /**
+     * @var \Drupal\Core\Entity\EntityManager
+     */
     protected $entityManager;
+
+    /**
+     * @var []
+     */
     protected $definitions;
+
+    /**
+     * @var \Drupal\Core\Config\StorageInterface
+     */
     protected $configStorage;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Command/ContainerAwareCommand.php
+++ b/src/Command/ContainerAwareCommand.php
@@ -188,6 +188,9 @@ abstract class ContainerAwareCommand extends Command
         return $this->getService('state');
     }
 
+    /**
+     * @return \Drupal\Core\Config\StorageInterface
+     */
     public function getConfigStorage()
     {
         return $this->getService('config.storage');
@@ -225,6 +228,9 @@ abstract class ContainerAwareCommand extends Command
         return $this->getService('event_dispatcher');
     }
 
+    /**
+     * @return \Drupal\Core\Entity\EntityManager
+     */
     public function getEntityManager()
     {
         return $this->getService('entity.manager');


### PR DESCRIPTION
Adds the boolean option, stealing some logic from features for calculating dependencies.

Adds return types to ContainerAwareCommand and the protected class members for functions used in this command.

Fixes #1817 