### PR TITLE
[config:diff] Add new command.

### DIFF
--- a/config/translations/en/config.diff.yml
+++ b/config/translations/en/config.diff.yml
@@ -1,0 +1,14 @@
+description: 'Ouput configuration items that are different in active configuration compared with a directory.'
+arguments:
+    directory: 'The directory to diff against. If ommitted, choose from Drupal config directories.'
+options:
+    reverse: 'See the changes in reverse (i.e diff a directory to the active configuration).'
+questions:
+    directories: 'Config directory:'
+table:
+    headers:
+      collection: 'Collection'
+      config-name: 'Configuration item'
+      operation: 'Operation'
+messages:
+    no-changes: 'There are no changes.'

--- a/src/Command/Config/DiffCommand.php
+++ b/src/Command/Config/DiffCommand.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Config\DiffCommand.
+ */
+
+namespace Drupal\Console\Command\Config;
+
+use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Config\StorageComparer;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\Console\Command\ContainerAwareCommand;
+use Drupal\Console\Style\DrupalStyle;
+
+class DiffCommand extends ContainerAwareCommand
+{
+
+    /**
+     * A static array map of operations -> color strings.
+     *
+     * @see http://symfony.com/doc/current/components/console/introduction.html#coloring-the-output
+     *
+     * @var array
+     */
+    protected static $operationColours = [
+        'delete' => '<fg=red>%s</fg=red>',
+        'update' => '<fg=yellow>%s</fg=yellow>',
+        'create' => '<fg=green>%s</fg=green>',
+        'default' => '%s',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('config:diff')
+            ->setDescription($this->trans('commands.config.diff.description'))
+            ->addArgument(
+                'directory',
+                InputArgument::OPTIONAL,
+                $this->trans('commands.config.diff.arguments.directory')
+            )
+            ->addOption(
+                'reverse',
+                NULL,
+                InputOption::VALUE_NONE,
+                $this->trans('commands.config.diff.options.reverse')
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        global $config_directories;
+        $io = new DrupalStyle($input, $output);
+
+        $directory = $input->getArgument('directory');
+        if (!$directory) {
+            $directory = $io->choice(
+                $this->trans('commands.config.diff.questions.directories'),
+                array_keys($config_directories),
+                CONFIG_SYNC_DIRECTORY
+            );
+
+            $input->setArgument('directory', $config_directories[$directory]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+        $directory = $input->getArgument('directory');
+        $source_storage = new FileStorage($directory);
+        $active_storage = $this->getConfigStorage();
+        $config_manager = $this->getConfigManager();
+
+        if ($input->getOption('reverse')) {
+            $config_comparer = new StorageComparer($source_storage, $active_storage, $config_manager);
+        }
+        else {
+            $config_comparer = new StorageComparer($active_storage, $source_storage, $config_manager);
+        }
+        if (!$config_comparer->createChangelist()->hasChanges()) {
+            $output->writeln($this->trans('commands.config.diff.messages.no-changes'));
+        }
+
+        $change_list = [];
+        foreach ($config_comparer->getAllCollectionNames() as $collection) {
+            $change_list[$collection] = $config_comparer->getChangelist(NULL, $collection);
+        }
+
+        $this->outputDiffTable($io, $change_list);
+    }
+
+    /**
+     * Ouputs a table of configuration changes.
+     *
+     * @param DrupalStyle $io
+     *   The io.
+     * @param array $change_list
+     *   The list of changes from the StorageComparer.
+     */
+    protected function outputDiffTable(DrupalStyle $io, array $change_list)
+    {
+        $header = [
+            $this->trans('commands.config.diff.table.headers.collection'),
+            $this->trans('commands.config.diff.table.headers.config-name'),
+            $this->trans('commands.config.diff.table.headers.operation'),
+        ];
+        $rows = [];
+        foreach ($change_list as $collection => $changes) {
+            foreach ($changes as $operation => $configs) {
+                foreach($configs as $config) {
+                    $rows[] = [
+                        $collection,
+                        $config,
+                        sprintf(self::$operationColours[$operation], $operation),
+                    ];
+                }
+            }
+        }
+        $io->table($header, $rows);
+    }
+
+}


### PR DESCRIPTION
New command.

Outputs a table of config changes between active configuration and a directory which can either be passed in or interactively chosen from a list of core's $config_directories.

Option ````--reverse```` to get a reverse output (i.e diff SOURCE ACTIVE)

Should be extended later with a verbose option to print the actual changes, possible in another table column, more likely in a big ugly list :)

Fixes #1821 
