### PR TITLE
[site:install] Account mail may be the same as defined for site mail

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -261,7 +261,7 @@ class InstallCommand extends Command
         if (!$account_mail) {
             $account_mail = $io->ask(
                 $this->trans('commands.site.install.questions.account-mail'),
-                'admin@example.com'
+                $site_mail
             );
             $input->setOption('account-mail', $account_mail);
         }


### PR DESCRIPTION
This same behavior has the installer via web