### PR TITLE
[generate:entity:content] Remove the action add link for canonical link

### DIFF
--- a/templates/module/links.action-entity-content.yml.twig
+++ b/templates/module/links.action-entity-content.yml.twig
@@ -8,5 +8,3 @@ entity.{{ entity_name }}.add_form:
   title: 'Add {{ label }}'
   appears_on:
     - entity.{{ entity_name }}.collection
-    - entity.{{ entity_name }}.canonical
-


### PR DESCRIPTION
In the view of an entity, the action link "Add {entity}" is displayed. This should only be displayed in the collection.