### PR TITLE
#1875 [generate:entity:content] EntityManager is deprecated.

### DIFF
--- a/templates/module/src/Controller/controller-add-page.php.twig
+++ b/templates/module/src/Controller/controller-add-page.php.twig
@@ -11,7 +11,7 @@ namespace Drupal\{{module}}\Controller;
 {% block use_class %}
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -41,11 +41,11 @@ class {{ class_name }} extends ControllerBase {% endblock %}
      * {@inheritdoc}
      */
     public static function create(ContainerInterface $container) {
-      /** @var EntityManagerInterface $entity_manager */
-      $entity_manager = $container->get('entity.manager');
+      /** @var EntityTypeManagerInterface $entity_type_manager */
+      $entity_type_manager = $container->get('entity_type.manager');
       return new static(
-        $entity_manager->getStorage('{{ entity_name }}'),
-        $entity_manager->getStorage('{{ bundle_entity_type }}')
+        $entity_type_manager->getStorage('{{ entity_name }}'),
+        $entity_type_manager->getStorage('{{ bundle_entity_type }}')
       );
     }
 {% endblock %}

--- a/templates/module/src/Controller/controller-entity.php.twig
+++ b/templates/module/src/Controller/controller-entity.php.twig
@@ -61,8 +61,8 @@ class {{ class_name }} extends ControllerBase {% endblock %}
         $content = array();
 
         // Only use node types the user has access to.
-        foreach ($this->entityManager()->getStorage('node_type')->loadMultiple() as $type) {
-            if ($this->entityManager()->getAccessControlHandler('node')->createAccess($type->id())) {
+        foreach ($this->entityTypeManager()->getStorage('node_type')->loadMultiple() as $type) {
+            if ($this->entityTypeManager()->getAccessControlHandler('node')->createAccess($type->id())) {
                 $content[$type->id()] = $type;
             }
         }
@@ -89,7 +89,7 @@ class {{ class_name }} extends ControllerBase {% endblock %}
     *   A node submission form.
     */
     public function add(EntityTypeInterface $entity_type) {
-        $node = $this->entityManager()->getStorage('node')->create(array(
+        $node = $this->entityTypeManager()->getStorage('node')->create(array(
             'type' => $node_type->id(),
         ));
 


### PR DESCRIPTION
I have tested this by running 

drupal generate:entity:content

and using it by visiting

/admin/structure/default_entity_type/add

All seems to work fine.