### PR TITLE
Postgres support for database commands

### DIFF
--- a/config/translations/en/database.log.clear.yml
+++ b/config/translations/en/database.log.clear.yml
@@ -1,4 +1,10 @@
 description: 'Remove events from DBLog table, filters are available'
+arguments:
+    event-id: 'DBLog event ID'
+options:
+    type: 'Filter events by a specific type'
+    severity: 'Filter events by a specific level of severity'
+    user-id: 'Filter events by a specific user id'
 messages:
     event-deleted: 'Event %s was deleted'
     clear-error: 'Clear process fail, please check used filters'

--- a/config/translations/en/database.restore.yml
+++ b/config/translations/en/database.restore.yml
@@ -5,3 +5,5 @@ options:
   file: 'The filename for your database backup file'
 messages:
     success: "Database imported from:"
+    no-file: "Missing file option"
+help: "Restore structure and contents of a database."

--- a/src/Command/Database/ConnectTrait.php
+++ b/src/Command/Database/ConnectTrait.php
@@ -11,6 +11,8 @@ use Drupal\Console\Style\DrupalStyle;
 
 trait ConnectTrait
 {
+    protected $supportedDrivers = Array('mysql','pgsql');
+
     public function resolveConnection(DrupalStyle $io, $database = 'default')
     {
         $connectionInfo = $this->getConnectionInfo();
@@ -27,7 +29,7 @@ trait ConnectTrait
         }
 
         $databaseConnection = $connectionInfo[$database];
-        if ($databaseConnection['driver'] !== 'mysql') {
+        if (!in_array($databaseConnection['driver'],$this->supportedDrivers)) {
             $io->error(
                 sprintf(
                     $this->trans('commands.database.connect.messages.database-not-supported'),

--- a/src/Command/Database/DumpCommand.php
+++ b/src/Command/Database/DumpCommand.php
@@ -58,15 +58,17 @@ class DumpCommand extends ContainerAwareCommand
 
         if (!$file) {
             $date = new \DateTime();
+            $siteRoot = rtrim($this->getSite()->getSiteRoot(), '/');
             $file = sprintf(
                 '%s/%s-%s.sql',
-                $this->getSite()->getSiteRoot(),
+                $siteRoot,
                 $databaseConnection['database'],
                 $date->format('Y-m-d-h-i-s')
             );
         }
 
-        $command = sprintf(
+        if($databaseConnection['driver'] == 'mysql') {
+          $command = sprintf(
             'mysqldump --user=%s --password=%s --host=%s --port=%s %s > %s',
             $databaseConnection['username'],
             $databaseConnection['password'],
@@ -74,7 +76,18 @@ class DumpCommand extends ContainerAwareCommand
             $databaseConnection['port'],
             $databaseConnection['database'],
             $file
-        );
+          );
+        } elseif($databaseConnection['driver'] == 'pgsql'){
+          $command = sprintf(
+            'PGPASSWORD="%s" pg_dump -U %s -w --host=%s --port=%s %s > %s',
+            $databaseConnection['password'],
+            $databaseConnection['username'],
+            $databaseConnection['host'],
+            $databaseConnection['port'],
+            $databaseConnection['database'],
+            $file
+          );
+        }
 
         if ($learning) {
             $io->commentBlock($command);

--- a/src/Command/Database/DumpCommand.php
+++ b/src/Command/Database/DumpCommand.php
@@ -79,7 +79,7 @@ class DumpCommand extends ContainerAwareCommand
           );
         } elseif($databaseConnection['driver'] == 'pgsql'){
           $command = sprintf(
-            'PGPASSWORD="%s" pg_dump -U %s -w --host=%s --port=%s %s > %s',
+            'PGPASSWORD="%s" pg_dumpall -w -U %s -h %s -p %s -l %s -f %s',
             $databaseConnection['password'],
             $databaseConnection['username'],
             $databaseConnection['host'],

--- a/src/Command/Database/RestoreCommand.php
+++ b/src/Command/Database/RestoreCommand.php
@@ -74,14 +74,13 @@ class RestoreCommand extends ContainerAwareCommand
           );
         } elseif($databaseConnection['driver'] == 'pgsql'){
           $command = sprintf(
-            //'PGPASSWORD="%s" pg_restore -U %s --host=%s --port=%s -C -d cat %s | psql dbnaem %s',
-          'PGPASSWORD="%s" psql -w -U %s -h %s -p %s -f %s %s',
+            'PGPASSWORD="%s" psql -w -U %s -h %s -p %s -d %s -f %s',
             $databaseConnection['password'],
-         $databaseConnection['username'],
-           $databaseConnection['host'],
+            $databaseConnection['username'],
+            $databaseConnection['host'],
             $databaseConnection['port'],
-            $file,
-            $databaseConnection['database']
+            $databaseConnection['database'],
+            $file
           );
         }
 

--- a/src/Command/Database/RestoreCommand.php
+++ b/src/Command/Database/RestoreCommand.php
@@ -62,8 +62,8 @@ class RestoreCommand extends ContainerAwareCommand
             );
             return;
         }
-
-        $command = sprintf(
+        if($databaseConnection['driver'] == 'mysql'){
+          $command = sprintf(
             'mysql --user=%s --password=%s --host=%s --port=%s %s < %s',
             $databaseConnection['username'],
             $databaseConnection['password'],
@@ -71,7 +71,19 @@ class RestoreCommand extends ContainerAwareCommand
             $databaseConnection['port'],
             $databaseConnection['database'],
             $file
-        );
+          );
+        } elseif($databaseConnection['driver'] == 'pgsql'){
+          $command = sprintf(
+            //'PGPASSWORD="%s" pg_restore -U %s --host=%s --port=%s -C -d cat %s | psql dbnaem %s',
+          'PGPASSWORD="%s" psql -w -U %s -h %s -p %s -f %s %s',
+            $databaseConnection['password'],
+         $databaseConnection['username'],
+           $databaseConnection['host'],
+            $databaseConnection['port'],
+            $file,
+            $databaseConnection['database']
+          );
+        }
 
         if ($learning) {
             $io->commentBlock($command);


### PR DESCRIPTION
Added ability for sites using 'pgsql' driver to use the "database" commands. Successfully tested all "database" commands with Postgres 9.4. Restore command works on an existing DB, but throws an error if db tables don't already exist. This seems to be a general issue with Drupal 8 support for Postgres and the different method (compared to MySQL) Postgres dumps a database. 