### PR TITLE
[generate:entity:content] added a generator for hook_theme_suggestion…

### DIFF
--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -169,6 +169,20 @@ class EntityContentGenerator extends Generator
                 $parameters,
                 FILE_APPEND
             );
+
+            if (strpos($module_file_contents, 'function ' . $module . '_theme_suggestions_' . $entity_name) !== false) {
+                echo "================\nWarning:\n================\n" .
+                  "It looks like you have a hook_theme_suggestions_HOOK already declared!\n".
+                  "Please manually merge the two hook_theme_suggestions_HOOK() implementations in $module_filename!\n";
+            }
+
+            $this->renderFile(
+              'module/src/Entity/entity-content-with-bundle.theme_hook_suggestions.php.twig',
+              $this->getSite()->getModulePath($module).'/'.$module.'.module',
+              $parameters,
+              FILE_APPEND
+            );
+
         }
 
         $content = $this->getRenderHelper()->render(

--- a/templates/module/src/Entity/entity-content-with-bundle.theme_hook_suggestions.php.twig
+++ b/templates/module/src/Entity/entity-content-with-bundle.theme_hook_suggestions.php.twig
@@ -1,0 +1,18 @@
+{% block hook_theme_suggestions_hook %}
+
+/**
+* Implements hook_theme_suggestions_HOOK().
+*/
+function {{ module }}_theme_suggestions_{{ entity_name }}(array $variables) {
+  $suggestions = array();
+  $entity = $variables['elements']['#{{ entity_name }}'];
+  $sanitized_view_mode = strtr($variables['elements']['#view_mode'], '.', '_');
+
+  $suggestions[] = '{{ entity_name }}__' . $sanitized_view_mode;
+  $suggestions[] = '{{ entity_name }}__' . $entity->bundle();
+  $suggestions[] = '{{ entity_name }}__' . $entity->bundle() . '__' . $sanitized_view_mode;
+  $suggestions[] = '{{ entity_name }}__' . $entity->id();
+  $suggestions[] = '{{ entity_name }}__' . $entity->id() . '__' . $sanitized_view_mode;
+  return $suggestions;
+}
+{% endblock %}


### PR DESCRIPTION
If you generate a content entity with bundles the hook_theme_suggestions_HOOK add support for extra twig template suggestions.

For example, your entity is named "segment" with a bundle named "inline-image".
The following extra template suggestions are passed to the render engine.

<!-- FILE NAME SUGGESTIONS:
   * segment--4--default.html.twig
   * segment--4.html.twig
   * segment--inline-image--default.html.twig
   * segment--inline-image.html.twig
   * segment--default.html.twig
   * segment.html.twig
-->