### PR TITLE
Fix for check db-file and db-type for sqlite options

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -165,7 +165,8 @@ class InstallCommand extends Command
             if ($dbType == 'sqlite' && !$dbFile) {
                 $dbFile = $this->dbFileQuestion($io);
                 $input->setOption('db-file', $dbFile);
-            } else {
+            }
+            if ($dbType != 'sqlite') {
                 // --db-host option
                 $dbHost = $input->getOption('db-host');
                 if (!$dbHost) {


### PR DESCRIPTION
Software version:

    Drupal Console (0.10.12) | Drupal (8.0.3)

Command executed:

    drupal site:install --langcode=it --db-type=sqlite --db-file=sites/default/files/.ht.sqlite standard

When you need sqlite and in command line you specify db-type and db-file the command in interactive mode asks you also db host.
I think that the problem is in the "if" at line number 165 of InstallCommand.php file.

    https://github.com/hechoendrupal/DrupalConsole/blob/0.10.12/src/Command/Site/InstallCommand.php#L165

