### PR TITLE
Fixed default values for textfields and textareas on config forms.

### DIFF
--- a/config/translations/en/common.yml
+++ b/config/translations/en/common.yml
@@ -24,7 +24,9 @@ questions:
         type: Type
         invalid: 'Field Type "%s" is invalid.'
         description: Description
-        default-value: 'Default value'
+        default-value:
+            default-value: 'Default value'
+            checkboxes: 'Default value(s) separated by commas'
         weight: 'Weight for input item'
         title: 'Title'
         fieldset: 'Fieldset'

--- a/src/Command/FormTrait.php
+++ b/src/Command/FormTrait.php
@@ -136,11 +136,27 @@ trait FormTrait
                     $this->trans('commands.common.questions.inputs.description')
                 );
 
+                // Default value for input
+                switch ($input_type) {
+                    case 'checkboxes':
+                        $question = 'commands.common.questions.inputs.default-value.checkboxes';
+                        break;
+                    default:
+                        $question = 'commands.common.questions.inputs.default-value.default-value';
+                        break;
+                }
                 if ($input_type != 'fieldset') {
-                    // Default value for input
                     $default_value = $io->askEmpty(
-                        $this->trans('commands.common.questions.inputs.default-value')
+                        $this->trans($question)
                     );
+                }
+                if ($input_type == 'checkboxes') {
+                    // Prepare options as an array
+                    if (strlen(trim($default_value))) {
+                        // remove spaces in options and empty options
+                        $default_options = array_filter(array_map('trim', explode(',', $default_value)));
+                        $default_value = $default_options;
+                    }
                 }
 
                 // Weight for input

--- a/src/Generator/FormGenerator.php
+++ b/src/Generator/FormGenerator.php
@@ -58,6 +58,12 @@ class FormGenerator extends Generator
             $parameters
         );
 
+        // Render defaults YML file.
+        $this->renderFile(
+            'module/config/install/field.default.yml.twig',
+            $this->getSite()->getModulePath($module).'/config/install/'.$module.'.'.$parameters['class_name_short'].'.yml',
+            $parameters
+        );
 
         if ($menu_link_gen == true) {
             $this->renderFile(

--- a/templates/module/config/install/field.default.yml.twig
+++ b/templates/module/config/install/field.default.yml.twig
@@ -1,6 +1,13 @@
 {{ module_name }}:
 {% for input in inputs %}
 {% if input.default_value is defined and input.default_value|length %}
+{% if input.default_value is iterable %}
+  {{ input.name }}:
+{% for value in input.default_value %}
+    - {{ value }}
+{% endfor %}
+{% else %}
   {{ input.name }}: "{{ input.default_value }}"
+{% endif %}
 {% endif %}
 {% endfor %}

--- a/templates/module/config/install/field.default.yml.twig
+++ b/templates/module/config/install/field.default.yml.twig
@@ -1,0 +1,6 @@
+{{ module_name }}:
+{% for input in inputs %}
+{% if input.default_value is defined and input.default_value|length %}
+  {{ input.name }}: "{{ input.default_value }}"
+{% endif %}
+{% endfor %}

--- a/templates/module/src/Form/form-config.php.twig
+++ b/templates/module/src/Form/form-config.php.twig
@@ -93,7 +93,7 @@ class {{ class_name }} extends ConfigFormBase {% endblock %}
       '#size' => {{ input.size }},
 {% endif %}
 {% if input.type != 'password_confirm' and input.type != 'fieldset' %}
-      '#default_value' => $config->get('{{ input.name }}'),
+      '#default_value' => $config->get('{{module_name}}.{{ input.name }}'),
 {% endif %}
     ];
 {% endfor %}


### PR DESCRIPTION
When creating config forms, default values for fields are written on an YML file. Still needs work on field types other than textfields and textareas. 