### PR TITLE
Fix all coding standard issues and some typos in views field plugin generation.

### DIFF
--- a/templates/module/src/Plugin/Views/field/field.php.twig
+++ b/templates/module/src/Plugin/Views/field/field.php.twig
@@ -23,48 +23,47 @@ use Drupal\views\ResultRow;
  *
  * @ViewsField("{{ class_machine_name }}")
  */
- class {{ class_name }} extends FieldPluginBase {% endblock %}
+class {{ class_name }} extends FieldPluginBase {% endblock %}
 {% block class_methods %}
-/**
- * {@inheritdoc}
- */
- public function usesGroupBy() {
-   return FALSE;
- }
+  /**
+   * {@inheritdoc}
+   */
+  public function usesGroupBy() {
+    return FALSE;
+  }
 
-/**
- * {@inheritdoc}
- */
- public function query() {
-   // do nothing -- to override the parent query.
- }
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Do nothing -- to override the parent query.
+  }
 
-/**
- * {@inheritdoc}
- */
- protected function defineOptions() {
-   $options = parent::defineOptions();
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
 
-   $options['hide_alter_empty'] = array('default' => FALSE);
-   return $options;
- }
+    $options['hide_alter_empty'] = array('default' => FALSE);
+    return $options;
+  }
 
-/**
- * {@inheritdoc}
- */
- public function buildOptionsForm(&$form, FormStateInterface $form_state) {
-   parent::buildOptionsForm($form, $form_state);
- }
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+  }
 
-/**
- * {@inheritdoc}
- */
- public function render(ResultRow $values) {
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
     // Return a random text, here you can include your custom logic.
-    // Include any namespace required to call the method required to generte the
-    // output desired
+    // Include any namespace required to call the method required to generate
+    // the desired output.
     $random = new Random();
     return $random->name();
- }
-
+  }
 {% endblock %}


### PR DESCRIPTION
Hey there.

First of all, thanks so much for this tool. It's pretty much the most awesome ever.

Just noticed a non-ideal output from the generation of a views field plugin. Here is a PR that makes it output code that passes Drupal coding standards and fixes one typo (generte => generate).

I see in the travis file that there is some effort to try and check Drupal CS on build. Will look at that, and see if I can help with something there :)

Have a great day!