### PR TITLE
Make example chain create the wanted states in REST resource.

### DIFF
--- a/config/dist/chain/sample.yml
+++ b/config/dist/chain/sample.yml
@@ -88,7 +88,10 @@ commands:
       plugin-id: example_rest_resource
       plugin-label: Example Rest Resource
       plugin-url: example_rest_resource
-      plugin-states: 0, 1, 2
+      plugin-states:
+        - GET
+        - PUT
+        - POST
   - command: generate:service
     options:
       module: example


### PR DESCRIPTION
The config provided in the chain example does not create the intended REST states. 

Here is a PR fixing that.