### PR TITLE
Fix coding standards for REST resource generation.

### DIFF
--- a/templates/module/src/Plugin/Rest/Resource/rest.php.twig
+++ b/templates/module/src/Plugin/Rest/Resource/rest.php.twig
@@ -14,7 +14,6 @@ use Drupal\rest\Plugin\ResourceBase;
 use Drupal\rest\ResourceResponse;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Psr\Log\LoggerInterface;
 {% endblock %}
 
@@ -83,7 +82,7 @@ class {{ class_name }} extends ResourceBase {% endblock %}
       $plugin_id,
       $plugin_definition,
       $container->getParameter('serializer.formats'),
-      $container->get('logger.factory')->get('rest'),
+      $container->get('logger.factory')->get('{{module_name}}'),
       $container->get('current_user')
     );
   }
@@ -102,15 +101,10 @@ class {{ class_name }} extends ResourceBase {% endblock %}
 
     // You must to implement the logic of your REST Resource here.
     // Use current user after pass authentication to validate access.
-
-    /*
-    if(!$this->currentUser->hasPermission($permission)) {
-        throw new AccessDeniedHttpException();
+    if (!$this->currentUser->hasPermission('access content')) {
+      throw new AccessDeniedHttpException();
     }
-    */
 
-    // Throw an exception if it is required.
-    // throw new HttpException(t('Throw an exception if it is required.'));
     return new ResourceResponse("Implement REST State {{ state }}!");
   }
 {% endfor %}


### PR DESCRIPTION
OK, here I have actually changed a couple of things:

- There were to unused 'use' statements. `AccessDeniedHttpException` and `HttpException`.
- I decided to just use the former, since having it in a comment would not look very good while still passing standards for inline comments. Please chime in, if you disagree.
- I decided to just remove the latter, since I (personally) don't see what it adds of value to the user. Since we already show how to throw an AccessDeniedHttpException, I think people would figure these things out?
- Decided to get the logger service namespaced with our custom module (example). This does not relate to coding standards, so if you want me to add another PR for that line (or if you disagree), I am fine with that.

Thoughts?