### PR TITLE
Fix coding standards for config entities.

### DIFF
--- a/templates/module/src/interface-entity.php.twig
+++ b/templates/module/src/interface-entity.php.twig
@@ -18,5 +18,4 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
  */
 interface {{ entity_class }}Interface extends ConfigEntityInterface {% endblock %}
 {% block class_methods %}
-  // Add get/set methods for your configuration properties here.
-{% endblock %}
+  // Add get/set methods for your configuration properties here.{% endblock %}


### PR DESCRIPTION
OK, this change looks a little uglier actually. But it produces better output code, which I think is more important.

If we have the endblock on the next line, it will produce 2 blank lines, and the sniffer will complain.