### PR TITLE
Fixes class_name in rest.php.twig @file block.

### DIFF
--- a/templates/module/src/Plugin/Rest/Resource/rest.php.twig
+++ b/templates/module/src/Plugin/Rest/Resource/rest.php.twig
@@ -1,7 +1,7 @@
 {% extends "base/class.php.twig" %}
 
 {% block file_path %}
-\Drupal\{{module_name}}\Plugin\rest\resource\{{module_name}}.
+\Drupal\{{module_name}}\Plugin\rest\resource\{{class_name}}.
 {% endblock %}
 
 {% block namespace_class %}


### PR DESCRIPTION
The trailing {{ module_name }} should be {{ class_name }} in rest.php.twig.