### PR TITLE
[state:delete] Add new command, working progress of #1968

### DIFF
--- a/config/translations/en/state.delete.yml
+++ b/config/translations/en/state.delete.yml
@@ -1,0 +1,7 @@
+description: 'Delete State'
+arguments:
+    name: 'State name.'
+messages:
+    enter-name: 'State name must contain a value.'
+    state-not-exists: 'The state "%s" does not exists.'
+    deleted: 'State "%s" sucessfully deleted.'

--- a/src/Command/Config/DeleteCommand.php
+++ b/src/Command/Config/DeleteCommand.php
@@ -61,7 +61,6 @@ class DeleteCommand extends ContainerAwareCommand
             return 1;
         }
 
-        
         $configStorage = $this->getService('config.storage');
         if (!$configStorage->exists($name)) {
             $io->error(

--- a/src/Command/State/DeleteCommand.php
+++ b/src/Command/State/DeleteCommand.php
@@ -61,17 +61,16 @@ class DeleteCommand extends ContainerAwareCommand
             return 1;
         }
 
-        //        $keyValue = $this->getService('keyvalue');
-        //        if (!$keyValue->exists($name)) {
-        //            $io->error(
-        ////                sprintf(
-        ////                    $this->trans('commands.state.delete.messages.state-not-exists'),
-        ////                    $name
-        ////                )
-        //            );
-        //
-        //            return 1;
-        //        }
+        if (!$state->get($name)) {
+            $io->error(
+                sprintf(
+                    $this->trans('commands.state.delete.messages.state-not-exists'),
+                    $name
+                )
+            );
+
+            return 1;
+        }
 
         try {
             $state->delete($name);

--- a/src/Command/State/DeleteCommand.php
+++ b/src/Command/State/DeleteCommand.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Config\DeleteCommand.
+ */
+
+namespace Drupal\Console\Command\State;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\Console\Command\ContainerAwareCommand;
+use Drupal\Console\Style\DrupalStyle;
+
+class DeleteCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('state:delete')
+            ->setDescription($this->trans('commands.state.delete.description'))
+            ->addArgument(
+                'name',
+                InputArgument::OPTIONAL,
+                $this->trans('commands.state.delete.arguments.name')
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+        $name = $input->getArgument('name');
+        if (!$name) {
+            $keyValue = $this->getService('keyvalue');
+            $names = array_keys($keyValue->get('state')->getAll());
+            $name = $io->choiceNoList(
+                $this->trans('commands.state.delete.arguments.name'),
+                $names
+            );
+            $input->setArgument('name', $name);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+        $state = $this->getState();
+        $name = $input->getArgument('name');
+        if (!$name) {
+            $io->error($this->trans('commands.state.delete.messages.enter-name'));
+
+            return 1;
+        }
+
+        //        $keyValue = $this->getService('keyvalue');
+        //        if (!$keyValue->exists($name)) {
+        //            $io->error(
+        ////                sprintf(
+        ////                    $this->trans('commands.state.delete.messages.state-not-exists'),
+        ////                    $name
+        ////                )
+        //            );
+        //
+        //            return 1;
+        //        }
+
+        try {
+            $state->delete($name);
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+
+            return 1;
+        }
+
+        $io->success(
+            sprintf(
+                $this->trans('commands.state.delete.messages.deleted'),
+                $name
+            )
+        );
+    }
+}


### PR DESCRIPTION
This command works except the error if there is not that state is not available in the system.

I have comment this code out ....

``````
                $keyValue = $this->getService('keyvalue');
                if (!$keyValue->exists($name)) {
                    $io->error(
                        sprintf(
                            $this->trans('commands.state.delete.messages.state-not-exists'),
                            $name
                        )
                    );

                    return 1;
                }

``````

