### PR TITLE
[helper] replace entityManager to entityTypeManager

### DIFF
--- a/src/Helper/DrupalApiHelper.php
+++ b/src/Helper/DrupalApiHelper.php
@@ -8,7 +8,6 @@
 namespace Drupal\Console\Helper;
 
 use Symfony\Component\DomCrawler\Crawler;
-use Drupal\Console\Helper\Helper;
 use Drupal\Console\Utils\Create\Nodes;
 use Drupal\Console\Utils\Create\Terms;
 use Drupal\Console\Utils\Create\Vocabularies;

--- a/src/Utils/Create/Base.php
+++ b/src/Utils/Create/Base.php
@@ -10,7 +10,7 @@ namespace Drupal\Console\Utils\Create;
 use Drupal\Component\Utility\Random;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\field\FieldConfigInterface;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 
 /**
@@ -19,8 +19,8 @@ use Drupal\Core\Datetime\DateFormatterInterface;
  */
 abstract class Base
 {
-    /* @var EntityManagerInterface */
-    protected $entityManager = null;
+    /* @var EntityTypeManagerInterface */
+    protected $entityTypeManager = null;
 
     /* @var DateFormatterInterface */
     protected $dateFormatter = null;
@@ -33,14 +33,14 @@ abstract class Base
 
     /**
      * ContentNode constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityTypeManagerInterface $entityTypeManager
      * @param DateFormatterInterface $dateFormatter
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityTypeManagerInterface $entityTypeManager,
         DateFormatterInterface $dateFormatter
     ) {
-        $this->entityManager = $entityManager;
+        $this->entityTypeManager = $entityTypeManager;
         $this->dateFormatter = $dateFormatter;
     }
 
@@ -54,7 +54,7 @@ abstract class Base
         $bundle = $entity->bundle();
 
         $fields = array_filter(
-            $this->entityManager->getFieldDefinitions($entityTypeId, $bundle), function ($fieldDefinition) {
+            $this->entityTypeManager->getFieldDefinitions($entityTypeId, $bundle), function ($fieldDefinition) {
                 return $fieldDefinition instanceof FieldConfigInterface;
             }
         );
@@ -106,7 +106,7 @@ abstract class Base
     protected function getUserId()
     {
         if (!$this->users) {
-            $userStorage = $this->entityManager->getStorage('user');
+            $userStorage = $this->entityTypeManager->getStorage('user');
 
             $this->users = $userStorage->loadByProperties(['status' => true]);
         }

--- a/src/Utils/Create/Nodes.php
+++ b/src/Utils/Create/Nodes.php
@@ -8,9 +8,10 @@
 namespace Drupal\Console\Utils\Create;
 
 use Drupal\Console\Utils\Create\Base;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\node\Entity\Node;
 
 /**
  * Class Nodes
@@ -24,17 +25,17 @@ class Nodes extends Base
     /**
      * Nodes constructor.
      *
-     * @param EntityManagerInterface $entityManager
+     * @param EntityTypeManagerInterface $entityTypeManager
      * @param DateFormatterInterface $dateFormatter
      * @param array                  $bundles
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityTypeManagerInterface $entityTypeManager,
         DateFormatterInterface $dateFormatter,
         $bundles
     ) {
         $this->bundles = $bundles;
-        parent::__construct($entityManager, $dateFormatter);
+        parent::__construct($entityTypeManager, $dateFormatter);
     }
 
     /**
@@ -54,7 +55,7 @@ class Nodes extends Base
         $nodes = [];
         for ($i=0; $i<$limit; $i++) {
             $contentType = $contentTypes[array_rand($contentTypes)];
-            $node = $this->entityManager->getStorage('node')->create(
+            $node = $this->entityTypeManager->getStorage('node')->create(
                 [
                     'nid' => null,
                     'type' => $contentType,

--- a/src/Utils/Create/Terms.php
+++ b/src/Utils/Create/Terms.php
@@ -8,7 +8,7 @@
 namespace Drupal\Console\Utils\Create;
 
 use Drupal\Console\Utils\Create\Base;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Language\LanguageInterface;
 
@@ -24,17 +24,17 @@ class Terms extends Base
     /**
      * Terms constructor.
      *
-     * @param EntityManagerInterface $entityManager
+     * @param EntityTypeManagerInterface $entityTypeManager
      * @param DateFormatterInterface $dateFormatter
      * @param array                  $vocabularies
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityTypeManagerInterface $entityTypeManager,
         DateFormatterInterface $dateFormatter,
         $vocabularies
     ) {
         $this->vocabularies = $vocabularies;
-        parent::__construct($entityManager, $dateFormatter);
+        parent::__construct($entityTypeManager, $dateFormatter);
     }
 
     /**
@@ -54,7 +54,7 @@ class Terms extends Base
         $terms = [];
         for ($i=0; $i<$limit; $i++) {
             $vocabulary = $vocabularies[array_rand($vocabularies)];
-            $term = $this->entityManager->getStorage('taxonomy_term')->create(
+            $term = $this->entityTypeManager->getStorage('taxonomy_term')->create(
                 [
                     'vid' => $vocabulary,
                     'name' => $this->getRandom()->sentences(mt_rand(1, $nameWords), true),

--- a/src/Utils/Create/Users.php
+++ b/src/Utils/Create/Users.php
@@ -9,7 +9,7 @@ namespace Drupal\Console\Utils\Create;
 
 use Drupal\Console\Utils\Create\Base;
 use Drupal\Component\Utility\Unicode;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\user\Entity\Role;
@@ -26,17 +26,17 @@ class Users extends Base
     /**
      * Users constructor.
      *
-     * @param EntityManagerInterface $entityManager
+     * @param EntityTypeManagerInterface $entityTypeManager
      * @param DateFormatterInterface $dateFormatter
      * @param array                  $roles
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityTypeManagerInterface $entityTypeManager,
         DateFormatterInterface $dateFormatter,
         $roles
     ) {
         $this->roles = $roles;
-        parent::__construct($entityManager, $dateFormatter);
+        parent::__construct($entityTypeManager, $dateFormatter);
     }
 
     /**
@@ -59,7 +59,7 @@ class Users extends Base
         for ($i=0; $i<$limit; $i++) {
             $username = $this->getRandom()->word(mt_rand(6, 12));
 
-            $user = $this->entityManager->getStorage('user')->create(
+            $user = $this->entityTypeManager->getStorage('user')->create(
                 [
                     'name' => $username,
                     'mail' => $username . '@example.com',

--- a/src/Utils/Create/Vocabularies.php
+++ b/src/Utils/Create/Vocabularies.php
@@ -9,7 +9,7 @@ namespace Drupal\Console\Utils\Create;
 
 use Drupal\Console\Utils\Create\Base;
 use Drupal\Component\Utility\Unicode;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Language\LanguageInterface;
 
@@ -22,11 +22,11 @@ class Vocabularies extends Base
     /**
      * Vocabularies constructor.
      *
-     * @param EntityManagerInterface $entityManager
+     * @param EntityTypeManagerInterface $entityManager
      * @param DateFormatterInterface $dateFormatter
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityTypeManagerInterface $entityManager,
         DateFormatterInterface $dateFormatter
     ) {
         parent::__construct($entityManager, $dateFormatter);
@@ -48,7 +48,7 @@ class Vocabularies extends Base
         for ($i=0; $i<$limit; $i++) {
 
             // Create a vocabulary.
-            $vocabulary = $this->entityManager->getStorage('taxonomy_vocabulary')->create(
+            $vocabulary = $this->entityTypeManager->getStorage('taxonomy_vocabulary')->create(
                 [
                     'name' => $this->getRandom()->sentences(mt_rand(1, $nameWords), true),
                     'description' => $this->getRandom()->sentences(),


### PR DESCRIPTION
**Problem/Motivation**

EntityManager is deprecated and will be removed  before drupal 9.0.x 

In this PR  I just replace entityManager  in favor of  entityTypeManager.

We could even replace: 

`$node = $this->entityTypeManager->getStorage('node')->create(...)`

to
`$node = Node::create(...)`

I will create a another PR later. 

