### PR TITLE
[site:mode] Invalid message on copy problem

### DIFF
--- a/src/Command/Site/ModeCommand.php
+++ b/src/Command/Site/ModeCommand.php
@@ -126,7 +126,7 @@ class ModeCommand extends ContainerAwareCommand
             if (!copy($defaultServicesFile, $settingsServicesFile)) {
                 $io->error(
                     sprintf(
-                        '%s: %s /services.yml',
+                        '%s: %s/services.yml',
                         $this->trans('commands.site.mode.messages.error-copying-file'),
                         $directory
                     )


### PR DESCRIPTION
Hello,

This PR corrects typo on a path when there's a copy problem on services.yml (I though the command wasn't working because of that, but it was just the message that is wrong).

Regards,
Peekmo