### PR TITLE
[site:import:local] New command for "importing" existing sites.

### DIFF
--- a/config/translations/ca/site.import.local.yml
+++ b/config/translations/ca/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/ca/site.import.local.yml
+++ b/config/translations/ca/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/en/site.import.local.yml
+++ b/config/translations/en/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/en/site.import.local.yml
+++ b/config/translations/en/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/es/site.import.local.yml
+++ b/config/translations/es/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/es/site.import.local.yml
+++ b/config/translations/es/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/fr/site.import.local.yml
+++ b/config/translations/fr/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/fr/site.import.local.yml
+++ b/config/translations/fr/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/gu/site.import.local.yml
+++ b/config/translations/gu/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/gu/site.import.local.yml
+++ b/config/translations/gu/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/hi/site.import.local.yml
+++ b/config/translations/hi/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/hi/site.import.local.yml
+++ b/config/translations/hi/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/hu/site.import.local.yml
+++ b/config/translations/hu/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/hu/site.import.local.yml
+++ b/config/translations/hu/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/id/site.import.local.yml
+++ b/config/translations/id/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/id/site.import.local.yml
+++ b/config/translations/id/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/ja/site.import.local.yml
+++ b/config/translations/ja/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/ja/site.import.local.yml
+++ b/config/translations/ja/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/ko/site.import.local.yml
+++ b/config/translations/ko/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/ko/site.import.local.yml
+++ b/config/translations/ko/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/mr/site.import.local.yml
+++ b/config/translations/mr/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/mr/site.import.local.yml
+++ b/config/translations/mr/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/pa/site.import.local.yml
+++ b/config/translations/pa/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/pa/site.import.local.yml
+++ b/config/translations/pa/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/pt_br/site.import.local.yml
+++ b/config/translations/pt_br/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/pt_br/site.import.local.yml
+++ b/config/translations/pt_br/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/ro/site.import.local.yml
+++ b/config/translations/ro/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/ro/site.import.local.yml
+++ b/config/translations/ro/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/ru/site.import.local.yml
+++ b/config/translations/ru/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/ru/site.import.local.yml
+++ b/config/translations/ru/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/tl/site.import.local.yml
+++ b/config/translations/tl/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/tl/site.import.local.yml
+++ b/config/translations/tl/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/vn/site.import.local.yml
+++ b/config/translations/vn/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/vn/site.import.local.yml
+++ b/config/translations/vn/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/config/translations/zh_hans/site.import.local.yml
+++ b/config/translations/zh_hans/site.import.local.yml
@@ -1,0 +1,17 @@
+description: 'Import/Configure an existing local Drupal project'
+help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+arguments:
+    directory: 'Existing Drupal root directory'
+    name: 'Name that will be used to generate the site config'
+options:
+    environment: 'Name of the environment that is going to be imported'
+messages:
+    imported: 'The site has been imported successfully. You might want to run `drupal site:debug` to confirm that everything went well.'
+    error-missing: "The directory %s doesn't exist."
+    error-not-drupal: 'This is not a valid drupal root: %s'
+    error-writing: 'An error accurred while trying to write the config file: %s'
+questions:
+    directory: 'Enter the directory name where to install Drupal'
+    name: 'Enter the name of the site'
+    environment: 'Enter the site environment name'
+

--- a/config/translations/zh_hans/site.import.local.yml
+++ b/config/translations/zh_hans/site.import.local.yml
@@ -1,5 +1,5 @@
 description: 'Import/Configure an existing local Drupal project'
-help: 'The <info>site:import:local</info> does foobar lorem ipsum'
+help: 'The <info>site:import:local</info> does create the yaml configuration file for a local existing site.'
 arguments:
     directory: 'Existing Drupal root directory'
     name: 'Name that will be used to generate the site config'

--- a/src/Command/Site/ImportLocalCommand.php
+++ b/src/Command/Site/ImportLocalCommand.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Site\ImportCommand.
+ */
+
+namespace Drupal\Console\Command\Site;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+
+use Drupal\Console\Command\Command;
+use Drupal\Console\Style\DrupalStyle;
+
+use Drupal\Console\Helper\DrupalHelper;
+
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Exception\DumpException;
+
+class ImportLocalCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('site:import:local')
+            ->setDescription($this->trans('commands.site.import.local.description'))
+            ->addArgument(
+                'name',
+                InputArgument::REQUIRED,
+                $this->trans('commands.site.import.local.arguments.name')
+            )
+            ->addArgument(
+                'directory',
+                InputArgument::REQUIRED,
+                $this->trans('commands.site.import.local.arguments.directory')
+            )
+            ->addOption(
+                'environment',
+                NULL,
+                InputOption::VALUE_REQUIRED,
+                $this->trans('commands.site.import.local.options.environment'),
+                'local'
+            )
+            ->setHelp($this->trans('commands.site.import.local.help'));;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+
+        $site_name = $input->getArgument('name');
+        $directory = $input->getArgument('directory');
+
+        $fileSystem = new Filesystem();
+        if ( ! $fileSystem->exists($directory) ) {
+          $io->error(
+              sprintf(
+                  $this->trans('commands.site.import.local.messages.error-missing'),
+                  $directory
+              )
+          );
+
+          return;
+        }
+        
+        $drupal = $this->getDrupalHelper();
+        if ( !$drupal->isValidRoot($directory) ) {
+          $io->error(
+              sprintf(
+                  $this->trans('commands.site.import.local.messages.error-not-drupal'),
+                  $directory
+              )
+          );
+
+          return;
+        }
+
+        $environment = 'local';
+        if ($input->hasOption('environment')) {
+            $environment = $input->getOption('environment');
+        }
+
+        $site_conf = [
+          $environment => [
+            'root' => $drupal->getRoot(),
+            'host' => 'local',
+          ],
+        ];
+        $yaml = Yaml::dump($site_conf);
+
+        $config = $this->getApplication()->getConfig();
+        $userPath = sprintf('%s/.console/sites', $config->getUserHomeDir());
+        $confFile = sprintf('%s/%s.yml', $userPath, $site_name);
+
+        try {
+          $fileSystem->dumpFile($confFile, $yaml);
+
+        } catch (IOException $e) {
+          $io->error(
+              sprintf(
+                  $this->trans('commands.site.import.local.messages.error-writing'),
+                  $e->getMessage()
+              )
+          );
+
+          return;
+        }
+
+        $io->success(
+            sprintf(
+                $this->trans('commands.site.import.local.messages.imported')
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+
+        $directory = $input->getArgument('directory');
+        if (!$directory) {
+            $directory = $io->ask(
+                $this->trans('commands.site.import.local.questions.directory')
+            );
+            $input->setArgument('directory', $directory);
+        }
+
+        $directory = $input->getArgument('name');
+        if (!$directory) {
+            $directory = $io->ask(
+                $this->trans('commands.site.import.local.questions.name')
+            );
+            $input->setArgument('name', $directory);
+        }
+
+    }
+}


### PR DESCRIPTION
Currently it's very easy start using drupal console from scratch, however there's no automated way to start working on existing projects.
With this new command i want to allow users to simply add their existing local sites to the console configuration with a simple command.

Let me know what you think about this, i'm fully open to suggestions.