### PR TITLE
Made the default `yes` for generate:module .module file.

### DIFF
--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -309,7 +309,7 @@ class ModuleCommand extends GeneratorCommand
         if (!$moduleFile) {
             $moduleFile = $io->confirm(
                 $this->trans('commands.generate.module.questions.module-file'),
-                false
+                true
             );
             $input->setOption('module-file', $moduleFile);
         }


### PR DESCRIPTION

![2129-console-generate-module](https://cloud.githubusercontent.com/assets/12372245/14450620/f149400e-004d-11e6-9252-d3478771a4f8.gif)
#1964 