### PR TITLE
[config:override] Adding interaction 

### DIFF
--- a/config/translations/en/config.override.yml
+++ b/config/translations/en/config.override.yml
@@ -1,13 +1,17 @@
 description: 'Override config value in active configuration.'
+questions:
+    name: 'Enter configuration name'
+    key: 'Enter the configuration key'
+    value: 'Enter the configuration value'
 arguments:
-    config-name: 'Configuration name.'
-    key: Key
-    value: Value
+    name: 'Configuration name'
+    key: 'Key'
+    value: 'Value'
 messages:
     configuration: 'Configuration name'
     configuration-key: 'Configuration key'
     original: 'Original Value'
     updated: 'Override Value'
 examples:
-    - description: Set the Contact module flood limit to 10.
-      execution: drupal config:override contact.settings flood.limit 10
+    - description: 'Set the Contact module flood limit to 10.'
+      execution: 'drupal config:override contact.settings flood.limit 10'

--- a/config/translations/en/config.override.yml
+++ b/config/translations/en/config.override.yml
@@ -12,6 +12,7 @@ messages:
     configuration-key: 'Configuration key'
     original: 'Original Value'
     updated: 'Override Value'
+    invalid-name: 'Config object "%s", does not exists'
 examples:
     - description: 'Set the Contact module flood limit to 10.'
       execution: 'drupal config:override contact.settings flood.limit 10'

--- a/src/Command/Config/OverrideCommand.php
+++ b/src/Command/Config/OverrideCommand.php
@@ -37,9 +37,20 @@ class OverrideCommand extends ContainerAwareCommand
     {
         $io = new DrupalStyle($input, $output);
         $name = $input->getArgument('name');
+        $configFactory = $this->getConfigFactory();
+        $names = $configFactory->listAll();
+        if ($name) {
+            if (!in_array($name, $names)) {
+                $io->warning(
+                    sprintf(
+                        $this->trans('commands.config.override.messages.invalid-name'),
+                        $name
+                    )
+                );
+                $name = null;
+            }
+        }
         if (!$name) {
-            $configFactory = $this->getConfigFactory();
-            $names = $configFactory->listAll();
             $name = $io->choiceNoList(
                 $this->trans('commands.config.override.questions.name'),
                 $names

--- a/src/Command/Config/OverrideCommand.php
+++ b/src/Command/Config/OverrideCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Command\ContainerAwareCommand;
 use Drupal\Console\Style\DrupalStyle;
+use Drupal\Component\Serialization\Yaml;
 
 class OverrideCommand extends ContainerAwareCommand
 {
@@ -21,19 +22,58 @@ class OverrideCommand extends ContainerAwareCommand
             ->setName('config:override')
             ->setDescription($this->trans('commands.config.override.description'))
             ->addArgument(
-                'config-name',
+                'name',
                 InputArgument::REQUIRED,
-                $this->trans('commands.config.override.arguments.config-name')
+                $this->trans('commands.config.override.arguments.name')
             )
             ->addArgument('key', InputArgument::REQUIRED, $this->trans('commands.config.override.arguments.key'))
             ->addArgument('value', InputArgument::REQUIRED, $this->trans('commands.config.override.arguments.value'));
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+        $name = $input->getArgument('name');
+        if (!$name) {
+            $configFactory = $this->getService('config.factory');
+            $names = $configFactory->listAll();
+            $name = $io->choiceNoList(
+                $this->trans('commands.config.override.questions.name'),
+                $names
+            );
+            $input->setArgument('name', $name);
+        }
+        $key = $input->getArgument('key');
+        if (!$key) {
+            $configStorage = $this->getConfigStorage();
+            if ($configStorage->exists($name)) {
+                $configuration = $configStorage->read($name);
+            }
+            $key = $io->choiceNoList(
+                $this->trans('commands.config.override.questions.key'),
+                array_keys($configuration)
+            );
+            $input->setArgument('key', $key);
+        }
+        $value = $input->getArgument('value');
+        if(!$value){
+            $value = $io->ask(
+                $this->trans('commands.config.override.questions.value')
+            );
+            $input->setArgument('value', $value);
+        }
+    }
+    /**
+     * {@inheritdoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new DrupalStyle($input, $output);
 
-        $configName = $input->getArgument('config-name');
+        $configName = $input->getArgument('name');
         $key = $input->getArgument('key');
         $value = $input->getArgument('value');
 
@@ -57,12 +97,13 @@ class OverrideCommand extends ContainerAwareCommand
         $config->save();
     }
 
+
     protected function overrideConfiguration($config, $key, $value)
     {
         $result[] = [
-          'configuration' => $key,
-          'original' => $config->get($key),
-          'updated' => $value,
+            'configuration' => $key,
+            'original' => $config->get($key),
+            'updated' => $value,
         ];
         $config->set($key, $value);
 

--- a/src/Command/Config/OverrideCommand.php
+++ b/src/Command/Config/OverrideCommand.php
@@ -38,7 +38,7 @@ class OverrideCommand extends ContainerAwareCommand
         $io = new DrupalStyle($input, $output);
         $name = $input->getArgument('name');
         if (!$name) {
-            $configFactory = $this->getService('config.factory');
+            $configFactory = $this->getConfigFactory();
             $names = $configFactory->listAll();
             $name = $io->choiceNoList(
                 $this->trans('commands.config.override.questions.name'),


### PR DESCRIPTION
See more at https://github.com/hechoendrupal/DrupalConsole/issues/2091

Working in progress
----


![config-override-interact](https://cloud.githubusercontent.com/assets/6808460/14304229/f696ed28-fb65-11e5-882e-f4b52e7efdc0.gif)


However, if we pass a config that is not in the system is going to throw this error. 

> Recoverable fatal error: Argument 2 passed to Drupal\Console\Style\DrupalStyle::choiceNoList() must be of the type array, null given, called in /Users/darrylnorris/Desktop/DrupalConsole/src/Command/Config/OverrideCommand.php on line 58 and defined in Drupal\Console\Style\DrupalStyle->choiceNoList() (line 38 of /Users/darrylnorris/Desktop/DrupalConsole/src/Style/DrupalStyle.php).

![screen shot 2016-04-05 at 7 41 28 pm](https://cloud.githubusercontent.com/assets/6808460/14304292/6c321ff8-fb66-11e5-97ae-476e5540fc33.png)

There are two options to solve this issue:
 - We could not allow overriding any config that is not in the system. And this will throw an error if the config is not in the system.
 - Or we can make behave the same way as `state:override`, which ends up setting that as new config with a key and value.
