### PR TITLE
[module:uninstall] Interact and Question

### DIFF
--- a/config/translations/en/module.uninstall.yml
+++ b/config/translations/en/module.uninstall.yml
@@ -1,4 +1,7 @@
 description: 'Uninstall module or modules in the application'
+questions:
+    module: 'Enter module name'
+    invalid-module: 'Invalid module %s'
 options:
     module: 'Module or modules to be uninstalled should be separated by a comma'
     force: 'Do you want to ignore dependencies and forcefully uninstall the module?'

--- a/src/Command/Module/UninstallCommand.php
+++ b/src/Command/Module/UninstallCommand.php
@@ -16,15 +16,38 @@ use Drupal\Console\Style\DrupalStyle;
 
 class UninstallCommand extends ContainerAwareCommand
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function configure()
     {
         $this
             ->setName('module:uninstall')
             ->setDescription($this->trans('commands.module.uninstall.description'))
-            ->addArgument('module', InputArgument::REQUIRED, $this->trans('commands.module.uninstall.options.module'))
+            ->addArgument('module', InputArgument::REQUIRED, $this->trans('commands.module.uninstall.questions.module'))
             ->addOption('force', '', InputOption::VALUE_NONE, $this->trans('commands.module.uninstall.options.force'));
     }
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+        $module = $input->getArgument('module');
+        $modules = $this->getSite()->getModules(true, true, false, true, true, true);
 
+        if(!$module){
+            $module = $io->choiceNoList(
+                $this->trans('commands.module.uninstall.questions.module'),
+                $modules,
+                true
+            );
+            $input->setArgument('module', $module);
+        }
+    }
+    /**
+     * {@inheritdoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io =  new DrupalStyle($input, $output);
@@ -91,11 +114,12 @@ class UninstallCommand extends ContainerAwareCommand
 
                 return true;
             }
+
         }
 
         // Installing modules
         try {
-            // Install the modules.
+            // Uninstall the modules.
             $moduleInstaller->uninstall($module_list);
 
             $io->info(
@@ -109,7 +133,6 @@ class UninstallCommand extends ContainerAwareCommand
 
             return;
         }
-
         // Run cache rebuild to see changes in Web UI
         $this->getChain()->addCommand('cache:rebuild', ['cache' => 'discovery']);
     }


### PR DESCRIPTION
Fixes #2074
![module-uninstall-interact](https://cloud.githubusercontent.com/assets/6808460/14306859/c6eedc92-fb7f-11e5-8c47-ea4f2ab23c47.gif)

A nice improvement that we could do is adding the ability of multiples modules with commas. I personally do not like the behavior from the `module:install` where is going to loop and keep asking for the same question over and over again.