### PR TITLE
[container-aware] Moving strings to yml files so it can be translate.

### DIFF
--- a/config/translations/en/common.yml
+++ b/config/translations/en/common.yml
@@ -34,6 +34,8 @@ errors:
     module-dependency: 'Missing module dependency "%s" is not installed. Try module:install to install it.'
     class-name-empty: 'The Class name can not be empty'
     invalid-file-path: 'You must provide a valid file path'
+    module-exist: 'Module "%s" already exist.'
+    machine-name-duplicated: 'Machine name "%s" is duplicated.'
 status:
     enabled: Enabled
     disabled: Disabled

--- a/config/translations/en/container-aware.yml
+++ b/config/translations/en/container-aware.yml
@@ -1,0 +1,4 @@
+errors:
+  module-exist: 'Module "%s" already exist.'
+  machine-name:
+    duplicated: 'Machine name "%s" is duplicated.'

--- a/config/translations/en/container-aware.yml
+++ b/config/translations/en/container-aware.yml
@@ -1,4 +1,0 @@
-errors:
-  module-exist: 'Module "%s" already exist.'
-  machine-name:
-    duplicated: 'Machine name "%s" is duplicated.'

--- a/src/Command/ContainerAwareCommand.php
+++ b/src/Command/ContainerAwareCommand.php
@@ -454,7 +454,7 @@ abstract class ContainerAwareCommand extends Command
         $machine_name = $this->validateMachineName($machine_name);
         $modules = $this->getSite()->getModules(false, true, true, true, true, true);
         if (in_array($machine_name, $modules)) {
-            throw new \InvalidArgumentException(sprintf('Module "%s" already exist.', $machine_name));
+            throw new \InvalidArgumentException(sprintf('commands.container-aware.errors.module-exist', $machine_name));
         }
 
         return $machine_name;
@@ -480,7 +480,7 @@ abstract class ContainerAwareCommand extends Command
         $machine_name = $this->getValidator()->validateMachineName($machine_name);
 
         if ($this->getEntityManager()->hasDefinition($machine_name)) {
-            throw new \InvalidArgumentException(sprintf('Machine name "%s" is duplicated.', $machine_name));
+            throw new \InvalidArgumentException(sprintf('commands.container-aware.errors.machine-name.duplicated', $machine_name));
         }
 
         return $machine_name;

--- a/src/Command/ContainerAwareCommand.php
+++ b/src/Command/ContainerAwareCommand.php
@@ -454,7 +454,7 @@ abstract class ContainerAwareCommand extends Command
         $machine_name = $this->validateMachineName($machine_name);
         $modules = $this->getSite()->getModules(false, true, true, true, true, true);
         if (in_array($machine_name, $modules)) {
-            throw new \InvalidArgumentException(sprintf('commands.container-aware.errors.module-exist', $machine_name));
+            throw new \InvalidArgumentException(sprintf('commands.common.errors.module-exist', $machine_name));
         }
 
         return $machine_name;
@@ -480,7 +480,7 @@ abstract class ContainerAwareCommand extends Command
         $machine_name = $this->getValidator()->validateMachineName($machine_name);
 
         if ($this->getEntityManager()->hasDefinition($machine_name)) {
-            throw new \InvalidArgumentException(sprintf('commands.container-aware.errors.machine-name.duplicated', $machine_name));
+            throw new \InvalidArgumentException(sprintf('commands.common.errors.machine-name-duplicated', $machine_name));
         }
 
         return $machine_name;


### PR DESCRIPTION
### Problem / Motivation
The container aware command had some hardcore strings in command. Instead of having them on a YML file so it can be translatable. 

### Solution
- [x]  Move the strings into a yml file