### PR TITLE
Fix exception when php settings were being checked

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -250,9 +250,7 @@ class Application extends BaseApplication
 
         $skipCheck = [
           'check',
-          'settings:check',
           'init',
-          'settings:check'
         ];
         if (!in_array($commandName, $skipCheck) && $config->get('application.checked') != 'true') {
             $requirementChecker = $this->getContainerHelper()->get('requirement_checker');
@@ -262,11 +260,11 @@ class Application extends BaseApplication
             }
             $requirementChecker->validate($phpCheckFile);
             if (!$requirementChecker->isValid()) {
-                $command = $this->find('settings:check');
+                $command = $this->find('check');
                 return $this->doRunCommand($command, $input, $output);
             }
             if ($requirementChecker->isOverwritten()) {
-                $this->getChain()->addCommand('settings:check');
+                $this->getChain()->addCommand('check');
             } else {
                 $this->getChain()->addCommand(
                     'settings:set',


### PR DESCRIPTION
When settings were being checked in Application.php the following error was occuring due to the mismatch in command names.

`[Symfony\Component\Console\Exception\CommandNotFoundException]  
  Command "settings:check" is not defined.                        
  Did you mean one of these?                                      
      settings:set                                                
      settings:debug `