### PR TITLE
[console] Use the git commit ID for the version

### DIFF
--- a/box.json
+++ b/box.json
@@ -25,5 +25,6 @@
     "compression": "GZ",
     "main": "bin/drupal",
     "output": "drupal.phar",
-    "stub": true
+    "stub": true,
+    "git-version": "git_version"
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -30,7 +30,7 @@ class Application extends BaseApplication
     /**
      * @var string
      */
-    const VERSION = '1.0.0-alpha2';
+    const VERSION = '@git_version@';
 
     /**
      * @var string


### PR DESCRIPTION
This uses the git tag for the version, and adds a commit ID if you are using a version that has commits since the last tag.

This should make debugging easier as it's much clearer which version a user is running, and also there's no need to manually increase the version number each time.

This results in output like this:

> 10:41 DrupalConsole (use-git-version) php drupal.phar --version
Drupal Console version 1.0.0-alpha2-1-g3481b8b