### PR TITLE
[generate:form:config] Single quote in title or description results in parse error at module install #2205

### DIFF
--- a/templates/module/src/Form/form-alter.php.twig
+++ b/templates/module/src/Form/form-alter.php.twig
@@ -34,9 +34,9 @@ function {{ module }}_form_alter(&$form, FormStateInterface $form_state, $form_i
 {% for input in inputs %}
     $form['{{ input.name }}'] = array(
       '#type' => '{{ input.type }}',
-      '#title' => t('{{ input.label }}'),
+      '#title' => t('{{ input.label|e }}'),
     {%- if input.description is defined -%}
-      '#description' => t('{{ input.description }}'),
+      '#description' => t('{{ input.description|e }}'),
     {% endif %}
 {%- if input.options is defined and input.options|length -%}
       '#options' => {{ input.options }},

--- a/templates/module/src/Form/form-config.php.twig
+++ b/templates/module/src/Form/form-config.php.twig
@@ -78,9 +78,9 @@ class {{ class_name }} extends ConfigFormBase {% endblock %}
     $form['{{ input.name }}'] = [
 {% endif %}
       '#type' => '{{ input.type }}',
-      '#title' => $this->t('{{ input.label }}'),
+      '#title' => $this->t('{{ input.label|e }}'),
 {% if input.description is defined and input.description is not empty %}
-      '#description' => $this->t('{{ input.description }}'),
+      '#description' => $this->t('{{ input.description|e }}'),
 {% endif %}
 {% if input.options is defined and input.options is not empty %}
       '#options' => {{ input.options }},

--- a/templates/module/src/Form/form.php.twig
+++ b/templates/module/src/Form/form.php.twig
@@ -65,9 +65,9 @@ class {{ class_name }} extends FormBase {% endblock %}
     $form['{{ input.name }}'] = array(
 {% endif %}
       '#type' => '{{ input.type }}',
-      '#title' => $this->t('{{ input.label }}'),
+      '#title' => $this->t('{{ input.label|e }}'),
 {% if input.description|length %}
-      '#description' => $this->t('{{ input.description }}'),
+      '#description' => $this->t('{{ input.description|e }}'),
 {% endif %}
 {% if input.options|length %}
       '#options' => {{ input.options }},


### PR DESCRIPTION
[https://github.com/hechoendrupal/DrupalConsole/issues/2205](url)

## Problem/Motivation

If the title or description captured during the generation process for the form contain any single quotes, then the generated code contains a syntax error.

## Steps to reproduce

- drupal generate:form:config
- When asked for title include a ' in your description like: David's module
- When asked for the description include a ' in your description like. This is David's module config form
- Finish generation
- Enable the module containing the form

## Proposed Solution

Escaping title/description in the twig template for form.