### PR TITLE
Check for empty uri.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -205,7 +205,7 @@ class Application extends BaseApplication
         $uri = $input->getParameterOption(['--uri', '-l']);
 
         /*Checking if the URI has http of not in begenning*/
-        if(!preg_match('^(http|https)://', $uri)){
+        if($uri && !preg_match('^(http|https)://', $uri)){
             $uri = sprintf(
                 'http://%s',
                 $uri


### PR DESCRIPTION
This prevents exception dump

```zsh
sites/drupal/d8/www % drupal
PHP Warning:  preg_match(): No ending delimiter '^' found in /Users/clemens/lib/DrupalConsole/src/Application.php on line 208
PHP Stack trace:
PHP   1. {main}() /Users/clemens/lib/DrupalConsole/bin/drupal:0
PHP   2. require() /Users/clemens/lib/DrupalConsole/bin/drupal:4
PHP   3. Symfony\Component\Console\Application->run() /Users/clemens/lib/DrupalConsole/bin/drupal.php:104
PHP   4. Drupal\Console\Application->doRun() /Users/clemens/lib/DrupalConsole/vendor/symfony/console/Application.php:123
PHP   5. preg_match() /Users/clemens/lib/DrupalConsole/src/Application.php:208

Warning: preg_match(): No ending delimiter '^' found in /Users/clemens/lib/DrupalConsole/src/Application.php on line 208

Call Stack:
    0.0001     224048   1. {main}() /Users/clemens/lib/DrupalConsole/bin/drupal:0
    0.0004     254304   2. require('/Users/clemens/lib/DrupalConsole/bin/drupal.php') /Users/clemens/lib/DrupalConsole/bin/drupal:4
    0.5798    7190928   3. Symfony\Component\Console\Application->run() /Users/clemens/lib/DrupalConsole/bin/drupal.php:104
    0.5825    7551176   4. Drupal\Console\Application->doRun() /Users/clemens/lib/DrupalConsole/vendor/symfony/console/Application.php:123
    0.5913    7778864   5. preg_match() /Users/clemens/lib/DrupalConsole/src/Application.php:208
```