### PR TITLE
Fix getEntityManager

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -205,7 +205,7 @@ class Application extends BaseApplication
         $uri = $input->getParameterOption(['--uri', '-l']);
 
         /*Checking if the URI has http of not in begenning*/
-        if(!preg_match('^(http|https)://', $uri)){
+        if($uri && !preg_match('^(http|https)://', $uri)){
             $uri = sprintf(
                 'http://%s',
                 $uri


### PR DESCRIPTION
I cannot `drupal generate:entity:content` missed in ed5e408ab5b6d3864f994975c68b9b23fdb4f833 I guess.

> Fatal error: Call to undefined method Drupal\Console\Command\Generate\EntityContentCommand::getEntityManager() in /Users/clemens/lib/DrupalConsole/src/Command/ContainerAwareCommand.php on line 475