### PR TITLE
module:uninstall --composer:  

### DIFF
--- a/config/translations/en/module.uninstall.yml
+++ b/config/translations/en/module.uninstall.yml
@@ -12,3 +12,4 @@ messages:
     nothing: 'Nothing to do. All modules are already uninstalled'
     success: 'The following module(s) were uninstalled successfully: %s'
     missing: 'Unable to uninstall modules %s due to missing modules %s'
+    composer-success: 'The folowing module(s) were removed from Composer: %s'

--- a/src/Command/Module/UninstallCommand.php
+++ b/src/Command/Module/UninstallCommand.php
@@ -92,13 +92,12 @@ class UninstallCommand extends ContainerAwareCommand
                 if ($this->execProcess($cmd)) {
                     $io->success(
                         sprintf(
-                            $this->trans('commands.module.uninstall.messages.success'),
+                            $this->trans('commands.module.uninstall.messages.composer-success'),
                             $m
                         )
                     );
                 }
             }
-            return;
         }
 
         // Determine if some module request is missing


### PR DESCRIPTION
the command must execute both things:
1. remove package in composer.json
2. uninstall from Drupal as regular (manual) installed modules