### PR TITLE
Generate Content entities as translatable by default. fix 2354

### DIFF
--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -46,6 +46,8 @@ use Drupal\user\UserInterface;
  *     },
  *   },
  *   base_table = "{{ entity_name }}",
+ *   data_table = "{{ entity_name }}_field_data",
+ *   translatable = TRUE,
  *   admin_permission = "administer {{ label|lower }} entities",
  *   entity_keys = {
  *     "id" = "id",


### PR DESCRIPTION
Hi!

Currently when we generate a content entity using the command generate:entity:content it is not set to translatable. The problem comes when we have content already created and we need to set our entity as translatable. We can't set it as translatable just adding the properties needed to the annotation of the entity, additionally we have to write a hook_update_n for migrating our entities to the new database structure if we want to have our entity translatable and don't lose data.

As you can imagine, the process is not simple at all for end users, it can be really a problem and you need to have a deep knowledge about the update process. Because of that, I propose to set the entities generated by the console to translatable by default. Then users can configure them within the content translation module easily if they need to do it.
On the other hand, if translation is not needed, nothing happens.

Thanks for your awesome work with this project!