### PR TITLE
#2289 : Fix permission for access to the custom entity content overview.

### DIFF
--- a/templates/module/permissions-entity-content.yml.twig
+++ b/templates/module/permissions-entity-content.yml.twig
@@ -12,6 +12,9 @@ delete {{ label|lower }} entities:
 edit {{ label|lower }} entities:
   title: 'Edit {{ label }} entities'
 
+access {{ label|lower }} overview:
+  title: 'Access the {{ label }} overview page'
+
 view published {{ label|lower }} entities:
   title: 'View published {{ label }} entities'
 

--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -60,7 +60,7 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
           '_entity_list' => $entity_type_id,
           '_title' => "{$entity_type->getLabel()} list",
         ])
-        ->setRequirement('_permission', 'view {{ label|lower }} entities')
+        ->setRequirement('_permission', 'access {{ label|lower }} overview')
         ->setOption('_admin_route', TRUE);
 
       return $route;


### PR DESCRIPTION
Hi,

This pull request solves the problem with the permissions when a non admin user try to access to the content entity list generated by the command generate:entity:content .

The problem was that the permission "view {{ label|lower }} entities" is not defined at permissions-entity-content.yml.twig that's why an non user can't access to the entity list.

I changed the name of the permission for avoiding to confuse it with the publish and unplish ones, this name structure is the same that Node module does (access content overview).

Thanks!