### PR TITLE
2353 theme download

### DIFF
--- a/config/translations/en/module.download.yml
+++ b/config/translations/en/module.download.yml
@@ -17,3 +17,5 @@ messages:
     error-creating-folder: 'Error creating folder %s, please check your permissions'
     no-composer-repo: 'Please, configure Composer in ~/.console/config.yml'
     composer: 'Module %s was downloaded successfully using Composer'
+tips:
+  - tip: 'Pass a «true» value to «shellexec_output» key in your config.yml file to see interactively Composer''s output or «false» to hide it'

--- a/config/translations/en/site.new.yml
+++ b/config/translations/en/site.new.yml
@@ -22,3 +22,5 @@ questions:
     directory: 'Enter the directory name where to install Drupal'
     composer-release: 'Please, choose a Packagist Drupal release'
     stable: 'Do you want to use stable releases?'
+tips:
+  - tip: 'Pass a «true» value to «shellexec_output» key in your config.yml file to see interactively Composer''s output or «false» to hide it'

--- a/config/translations/en/theme.download.yml
+++ b/config/translations/en/theme.download.yml
@@ -1,11 +1,16 @@
 description: 'Download theme in application'
-options:
+arguments:
     version: 'Theme version i.e 1.x-dev'
+    theme: 'the Theme name'
+options:
+    composer: 'Use --composer option for manage the theme download with Composer'
 messages:
     no-releases: 'There aren''t any releases for theme %s'
     getting-releases: 'Getting releases for theme %s'
     downloading: 'Downloading theme %s release %s'
     downloaded: 'Theme %s version %s was downloaded successfully at %s'
     select-release: 'Please select your favorite release'
-    outside-drupal: "Drupal root can't be determined. Use --root to set the destination, current folder will be used instead of."
+    outside-drupal: 'Drupal root can''t be determined. Use --root to set the destination, current folder will be used instead of.'
     error-creating-folder: 'Error creating folder %s, please check your permissions'
+tips:
+  - tip: 'Pass a «true» value to «shellexec_output» key in your config.yml file to see interactively Composer''s output or «false» to hide it'

--- a/src/Command/Module/DownloadCommand.php
+++ b/src/Command/Module/DownloadCommand.php
@@ -119,6 +119,7 @@ class DownloadCommand extends Command
                             $versions
                         );
                     }
+
                 } else {
                     $versions = $this->getApplication()->getDrupalApi()
                         ->getPackagistModuleReleases($module, 10, $unstable);

--- a/src/EventSubscriber/ShowTipsListener.php
+++ b/src/EventSubscriber/ShowTipsListener.php
@@ -63,7 +63,7 @@ class ShowTipsListener implements EventSubscriberInterface
             return false;
         }
 
-        echo $n = rand(0, 5);
+        $n = rand(0, 5);
         $get_tip = $translatorHelper->trans('commands.'.str_replace(':', '.', $command->getName()).'.tips.' . $n . '.tip');
         preg_match("/^commands./", $get_tip, $matches, null, 0);
 


### PR DESCRIPTION
_theme:download --composer_ binds to _module:download --composer_
it downloads the theme well and _Composer_ manages where to put it

also, created a tip

> 'Pass a «true» value to «shellexec_output» key in your config.yml file to see interactively Composer''s output or «false» to hide it'

it appears in _site:new_, _module:download_ & _theme:download_

also removed a lost «`echo`» in _ShowTipsListener.php_
