### PR TITLE
Fix issue 2383-Form-alter

### DIFF
--- a/config/translations/en/generate.form.alter.yml
+++ b/config/translations/en/generate.form.alter.yml
@@ -6,3 +6,4 @@ messages:
     inputs: "You can add form fields to modify form.\nThis is optional, press <info>enter</info> to <info>continue</info>"
     loading-forms: Loading forms definition from Webprofiler module
     hide-form-elements: 'Optionally you can select form items for hide'
+    help-already-implemented: 'The hook form alter was already implemented in module "%s"'

--- a/src/Command/Generate/FormAlterCommand.php
+++ b/src/Command/Generate/FormAlterCommand.php
@@ -27,7 +27,7 @@ class FormAlterCommand extends GeneratorCommand
     use MenuTrait;
     use ConfirmationTrait;
 
-    protected $metadata = ['unset' => []];
+    protected $metadata = ['class' => [],'method'=> [],'file'=> [],'unset' => []];
 
     protected function configure()
     {

--- a/src/Command/Generate/FormAlterCommand.php
+++ b/src/Command/Generate/FormAlterCommand.php
@@ -53,8 +53,9 @@ class FormAlterCommand extends GeneratorCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
+    protected function execute(InputInterface $input, OutputInterface $output) 
+    {  
+
         $io = new DrupalStyle($input, $output);
 
         // @see use Drupal\Console\Command\Shared\ConfirmationTrait::confirmGeneration
@@ -65,6 +66,17 @@ class FormAlterCommand extends GeneratorCommand
         $module = $input->getOption('module');
         $formId = $input->getOption('form-id');
         $inputs = $input->getOption('inputs');
+
+        $function = $module . '_form_' .$formId . '_alter';
+        
+        if ($this->validateModuleFunctionExist($module, $function)) {
+            throw new \Exception(
+                sprintf(
+                    $this->trans('commands.generate.form.alter.messages.help-already-implemented'),
+                    $module
+                )
+            );
+        }
 
         //validate if input is an array
         if (!is_array($inputs[0])) {
@@ -79,7 +91,7 @@ class FormAlterCommand extends GeneratorCommand
     }
 
     protected function interact(InputInterface $input, OutputInterface $output)
-    {
+    {   
         $io = new DrupalStyle($input, $output);
 
         $moduleHandler = $this->getModuleHandler();
@@ -91,6 +103,7 @@ class FormAlterCommand extends GeneratorCommand
             // @see Drupal\Console\Command\Shared\ModuleTrait::moduleQuestion
             $module = $this->moduleQuestion($io);
         }
+       
         $input->setOption('module', $module);
 
         // --form-id option


### PR DESCRIPTION
When we try to execute the command : drupal gfa --module="myroute" --form-id="contact_message_product_information_form" , we get the following error 
 Key "class" does not exist as the array is empty in "module/src/Form/form-alter.php.twig" at line 10

 I just added the missing keys and now the command is working properly 
                                                                           
 