### PR TITLE
[generate:entity:content] RouteNotFoundException with bundles

### DIFF
--- a/templates/module/links.action-entity-content.yml.twig
+++ b/templates/module/links.action-entity-content.yml.twig
@@ -3,7 +3,7 @@ entity.{{ entity_name }}.add_form:
 {% if not bundle_entity_type %}
   route_name: entity.{{ entity_name }}.add_form
 {% else %}
-  route_name: '{{ entity_name }}.add_page'
+  route_name: 'entity.{{ entity_name }}.add_page'
 {% endif %}
   title: 'Add {{ label }}'
   appears_on:

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -63,6 +63,7 @@ use Drupal\user\UserInterface;
  *   links = {
  *     "canonical" = "{{ base_path }}/{{ entity_name }}/{{ '{'~entity_name~'}' }}",
 {% if bundle_entity_type %}
+ *     "add-page" = "{{ base_path }}/{{ entity_name }}/add",
  *     "add-form" = "{{ base_path }}/{{ entity_name }}/add/{{ '{'~bundle_entity_type~'}' }}",
 {% else %}
  *     "add-form" = "{{ base_path }}/{{ entity_name }}/add",


### PR DESCRIPTION
Drupal version 8.1.3
Drupal Console version 1.0.0-beta2

When you generate a content entity with bundles, you get a `Symfony\Component\Routing\Exception\RouteNotFoundException` on entity collection route.

**Reproducing steps:**
`drupal generate:module --module=foo`
Leave options as default.
`drupal generate:entity:content --module=foo --entity-class=Bar`
Leave options as default except for entity have bundles set to yes
When visiting `/admin/structure/bar` you should get the error.

![bug](https://cloud.githubusercontent.com/assets/20012052/16170666/baa3f5ba-355b-11e6-90c8-569b96572d2f.jpg)

**Proposed solution**

- Add an add-page link in content entity annotations to allow the route provider to create the route
- Prefix the entity `add_form` route name in action links file with `entity` so that the route name matches with the route provider one.