### PR TITLE
#2242 [generate:entity:content] Allow option to generate translatable content entities

### DIFF
--- a/Test/DataProvider/EntityContentDataProviderTrait.php
+++ b/Test/DataProvider/EntityContentDataProviderTrait.php
@@ -16,7 +16,7 @@ trait EntityContentDataProviderTrait
         $this->setUpTemporaryDirectory();
 
         return [
-          ['Foo', 'foo' . rand(), 'Bar', 'bar', 'admin/structure'],
+          ['Foo', 'foo' . rand(), 'Bar', 'bar', 'admin/structure', 'true'],
         ];
     }
 }

--- a/Test/Generator/EntityContentGeneratorTest.php
+++ b/Test/Generator/EntityContentGeneratorTest.php
@@ -30,7 +30,8 @@ class EntityContentGeneratorTest extends GeneratorTest
         $entity_name,
         $entity_class,
         $label,
-        $base_path
+        $base_path,
+        $is_translatable
     ) {
         $generator = new EntityContentGenerator();
         $this->getRenderHelper()->setSkeletonDirs($this->getSkeletonDirs());
@@ -42,7 +43,8 @@ class EntityContentGeneratorTest extends GeneratorTest
             $entity_name,
             $entity_class,
             $label,
-            $base_path
+            $base_path,
+            $is_translatable
         );
 
         $files = [

--- a/config/translations/ca/generate.entity.content.yml
+++ b/config/translations/ca/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: Etiqueta
     has-bundles: 'L''entitat conté bundles'
     base-path: 'El camí base per les rutes de l''entitat de continguts'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Introduïu la classe de la nova entitat de contingut'
@@ -14,3 +15,4 @@ questions:
     label: 'Introduïu l''etiqueta de la nova entitat de contingut'
     has-bundles: 'Vols que aquest contingut tingui bundles'
     base-path: 'Introduïu el camí base per les rutes de l''entitat de contigut'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/en/generate.entity.content.yml
+++ b/config/translations/en/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/es/generate.entity.content.yml
+++ b/config/translations/es/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: Etiqueta
     has-bundles: 'La entidad tiene bundles'
     base-path: 'El directorio raíz para las rutas de la entidad de contenido'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Proporcione la clase de la nueva entidad de contenido'
@@ -14,3 +15,4 @@ questions:
     label: 'Proporcione la etiqueta de la nueva entidad de contenido'
     has-bundles: 'Desea que esta entidad de contenido tenga bundles'
     base-path: 'Proporcione el directorio raíz para las rutas de la entidad de contenido'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/fr/generate.entity.content.yml
+++ b/config/translations/fr/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'Le libellé'
     has-bundles: 'Est-ce que l''entité possède des bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Entrez le nom de votre classe pour votre nouvelle entité de contenu'
@@ -14,3 +15,4 @@ questions:
     label: 'Entrez le libellé de votre nouvelle entité de contenu'
     has-bundles: 'Voulez-vous que cette entité possède des bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/gu/generate.entity.content.yml
+++ b/config/translations/gu/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/hi/generate.entity.content.yml
+++ b/config/translations/hi/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: लेबल
     has-bundles: 'एंटिटि मॆ बंडल हे'
     base-path: 'कॉन्फिग एंटिटी रुट्स के लिए बेस पथ'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'अपने नई कंटेंट एंटिटि की कक्षा लिखॆ'
@@ -14,3 +15,4 @@ questions:
     label: 'अपने नई कंटेंट एंटिटि का लेबल लिखॆ'
     has-bundles: 'आप (कंटेंट) एंटिटि  मे बंडल चाहते हैं'
     base-path: 'कॉन्फिग एंटिटी रुट्स के लिए बेस पथ दर्ज करे'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/hu/generate.entity.content.yml
+++ b/config/translations/hu/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'A felirat'
     has-bundles: 'Az entitás nem rendelkezik mezőcsoportokkal'
     base-path: 'A tartalom entitás útvonalak alapútvonala'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Meg kell adni az új tartalom entitás osztályát'
@@ -14,3 +15,4 @@ questions:
     label: 'Meg kell adni az új tartalom entitás feliratát'
     has-bundles: 'Ez a tartalom entitás rendelkezzen mezőcsoportokkal?'
     base-path: 'Meg kell adni a tartalom entitás útvonalak alapútvonalát'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/id/generate.entity.content.yml
+++ b/config/translations/id/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/ja/generate.entity.content.yml
+++ b/config/translations/ja/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/ko/generate.entity.content.yml
+++ b/config/translations/ko/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/mr/generate.entity.content.yml
+++ b/config/translations/mr/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/pa/generate.entity.content.yml
+++ b/config/translations/pa/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/pt_br/generate.entity.content.yml
+++ b/config/translations/pt_br/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'O rótulo'
     has-bundles: 'A entidade tem bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Digite a classe da sua nova entidade de conteúdo'
@@ -14,3 +15,4 @@ questions:
     label: 'Digite o rótulo da sua nova entidade de conteúdo'
     has-bundles: 'Deseja que esta entidade de conteúdo tenha bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/ro/generate.entity.content.yml
+++ b/config/translations/ro/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: Eticheta
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Introduceți clasa noii dvs. entități de conținut'
@@ -14,3 +15,4 @@ questions:
     label: 'Introduceți eticheta noii dvs. entități de conținut'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/ru/generate.entity.content.yml
+++ b/config/translations/ru/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/tl/generate.entity.content.yml
+++ b/config/translations/tl/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/vn/generate.entity.content.yml
+++ b/config/translations/vn/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: Nhãn
     has-bundles: 'Entity có các bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Nhập lớp của config entity mới của bạn'
@@ -14,3 +15,4 @@ questions:
     label: 'Nhập nhãn của config entity mới của bạn'
     has-bundles: 'Bạn có muốn (content) entity này có bundles không'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/zh_hans/generate.entity.content.yml
+++ b/config/translations/zh_hans/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 标签
     has-bundles: '实体包含 Bundles'
     base-path: 内容实体路由的基本路径
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 输入新内容实体的类名
@@ -14,3 +15,4 @@ questions:
     label: 输入新内容实体的标签
     has-bundles: '这个（内容）实体包含 Bundles 吗？'
     base-path: 输入内容实体路由的基本路径
+    is-translatable: 'Is your entity translatable'

--- a/config/translations/zh_hant/generate.entity.content.yml
+++ b/config/translations/zh_hant/generate.entity.content.yml
@@ -7,6 +7,7 @@ options:
     label: 'The label'
     has-bundles: 'Entity has bundles'
     base-path: 'The base-path for the content entity routes'
+    is-translatable: 'Content entity translatable'
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
@@ -14,3 +15,4 @@ questions:
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
+    is-translatable: 'Is your entity translatable'

--- a/src/Command/Generate/EntityContentCommand.php
+++ b/src/Command/Generate/EntityContentCommand.php
@@ -31,6 +31,13 @@ class EntityContentCommand extends EntityCommand
             InputOption::VALUE_NONE,
             $this->trans('commands.generate.entity.content.options.has-bundles')
         );
+
+        $this->addOption(
+            'is-translatable',
+            null,
+            InputOption::VALUE_NONE,
+            $this->trans('commands.generate.entity.content.options.is-translatable')
+        );
     }
 
     /**
@@ -50,6 +57,13 @@ class EntityContentCommand extends EntityCommand
             );
             $input->setOption('has-bundles', $bundle_of);
         }
+
+        // --is-translatable option
+        $is_translatable = $io->confirm(
+            $this->trans('commands.generate.entity.content.questions.is-translatable'),
+            true
+        );
+        $input->setOption('is-translatable', $is_translatable);
     }
 
     /**
@@ -65,13 +79,14 @@ class EntityContentCommand extends EntityCommand
         $base_path = $input->getOption('base-path');
         $learning = $input->hasOption('learning')?$input->getOption('learning'):false;
         $bundle_entity_name = $has_bundles ? $entity_name . '_type' : null;
+        $is_translatable = $input->hasOption('is-translatable') ? $input->getOption('is-translatable') : true;
 
         $io = new DrupalStyle($input, $output);
         $generator = $this->getGenerator();
         $generator->setIo($io);
         $generator->setLearning($learning);
 
-        $generator->generate($module, $entity_name, $entity_class, $label, $base_path, $bundle_entity_name);
+        $generator->generate($module, $entity_name, $entity_class, $label, $base_path, $is_translatable, $bundle_entity_name);
 
         if ($has_bundles) {
             $this->getChain()->addCommand(

--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -17,9 +17,10 @@ class EntityContentGenerator extends Generator
      * @param string $entity_class       Entity class name
      * @param string $label              Entity label
      * @param string $base_path          Base path
+     * @param string $is_translatable    Translation configuration
      * @param string $bundle_entity_type (Config) entity type acting as bundle
      */
-    public function generate($module, $entity_name, $entity_class, $label, $base_path, $bundle_entity_type = null)
+    public function generate($module, $entity_name, $entity_class, $label, $base_path, $is_translatable, $bundle_entity_type = null)
     {
         $parameters = [
             'module' => $module,
@@ -28,6 +29,7 @@ class EntityContentGenerator extends Generator
             'label' => $label,
             'bundle_entity_type' => $bundle_entity_type,
             'base_path' => $base_path,
+            'is_translatable' => $is_translatable,
         ];
 
         $this->renderFile(
@@ -63,6 +65,14 @@ class EntityContentGenerator extends Generator
             $this->getSite()->getSourcePath($module).'/'.$entity_class.'AccessControlHandler.php',
             $parameters
         );
+
+        if ($is_translatable) {
+            $this->renderFile(
+                'module/src/entity-translation-handler.php.twig',
+                $this->getSite()->getSourcePath($module).'/'.$entity_class.'TranslationHandler.php',
+                $parameters
+            );
+        }
 
         $this->renderFile(
             'module/src/Entity/interface-entity-content.php.twig',

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -33,6 +33,9 @@ use Drupal\user\UserInterface;
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\{{ module }}\{{ entity_class }}ListBuilder",
  *     "views_data" = "Drupal\{{ module }}\Entity\{{ entity_class }}ViewsData",
+{% if is_translatable %}
+ *     "translation" = "Drupal\{{ module }}\{{ entity_class }}TranslationHandler",
+{% endif %}
  *
  *     "form" = {
  *       "default" = "Drupal\{{ module }}\Form\{{ entity_class }}Form",
@@ -46,8 +49,10 @@ use Drupal\user\UserInterface;
  *     },
  *   },
  *   base_table = "{{ entity_name }}",
+{% if is_translatable %}
  *   data_table = "{{ entity_name }}_field_data",
  *   translatable = TRUE,
+ {% endif %}
  *   admin_permission = "administer {{ label|lower }} entities",
  *   entity_keys = {
  *     "id" = "id",

--- a/templates/module/src/entity-translation-handler.php.twig
+++ b/templates/module/src/entity-translation-handler.php.twig
@@ -1,0 +1,18 @@
+{% extends "base/class.php.twig" %}
+
+{% block namespace_class %}
+namespace Drupal\{{module}};
+{% endblock %}
+
+{% block use_class %}
+use Drupal\content_translation\ContentTranslationHandler;
+{% endblock %}
+
+{% block class_declaration %}
+/**
+ * Defines the translation handler for {{ entity_name }}.
+ */
+class {{ entity_class }}TranslationHandler extends ContentTranslationHandler {% endblock %}
+{% block class_methods %}
+  // Override here the needed methods from ContentTranslationHandler.
+{% endblock %}


### PR DESCRIPTION
This pull request try to solve #2242 

- Added a new option for set the new content entities as translatable or not.
- In case the entity is set as translatable the annotation is updated according to that and a translationHandler class is added. Nothing is done in other case.

```
$ drupal-console generate:entity:content
 Enter the module name [block_example]:
 > lopd

 Enter the class of your new content entity [DefaultEntity]:
 > ContentEntity

 Enter the name of your new content entity [content_entity]:
 > 

 Enter the label of your new content entity [Content entity]:
 > 

 Enter the base-path for the content entity routes [/admin/structure]:
 > 


 Do you want this (content) entity to have bundles (yes/no) [no]:
 > 

 Is your entity translatable (yes/no) [yes]:

```