### PR TITLE
[translation] generate:entity:content should ask for machine name (english)

### DIFF
--- a/config/translations/en/generate.entity.content.yml
+++ b/config/translations/en/generate.entity.content.yml
@@ -10,7 +10,7 @@ options:
 questions:
     module: common.questions.module
     entity-class: 'Enter the class of your new content entity'
-    entity-name: 'Enter the name of your new content entity'
+    entity-name: 'Enter the machine name of your new content entity'
     label: 'Enter the label of your new content entity'
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'


### PR DESCRIPTION
generate:entity:content command asks for a name for the entity but the request should be for a machine name