### PR TITLE
Added Drupal-Packagist repo for searching the module

### DIFF
--- a/src/Command/Module/DebugCommand.php
+++ b/src/Command/Module/DebugCommand.php
@@ -55,6 +55,8 @@ class DebugCommand extends Command
 
         if ($modules) {
             $config = $this->getApplication()->getConfig();
+            $repo = $config->get('application.composer.repositories.default');
+
             foreach ($modules as $module) {
                 $url = sprintf(
                     '%s/packages/drupal/%s.json',
@@ -63,7 +65,8 @@ class DebugCommand extends Command
                 );
 
                 try {
-                    $data = $this->getApplication()->getHttpClientHelper()->getUrlAsJson($url);
+                    $data = $this->getApplication()->getHttpClientHelper()->getUrlAsJson($repo . $url);
+
                 } catch (\Exception $e) {
                     $io->error(
                         sprintf(


### PR DESCRIPTION
drupal module:debug module_name wasn't working because it wasn't find any repo to search the module.
i added `https://packagist.drupal-composer.org/` before the module name in order `drupal console` find it there.

it's working for me now ^^

![seleccion_728](https://cloud.githubusercontent.com/assets/423279/16361527/7c2e00a8-3b93-11e6-8998-b7a697bfcbb8.png)


this PR comes from #2292