### PR TITLE
[config:export] Fix PHP warnings and notices

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -50,7 +50,6 @@ class ExportCommand extends Command
 
         $directory = $input->getOption('directory');
         $tar = $input->getOption('tar');
-        $archiveTar = new ArchiveTar();
 
         if (!$directory) {
             $directory = config_get_config_directory(CONFIG_SYNC_DIRECTORY);


### PR DESCRIPTION
ArchiveTar takes an argument in the constructor, this is causing warnings and notices during a config export command.

The variable is overwritten soon after in the conditional so is unnecessary.
