### PR TITLE
[site:install] Allow re-install

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -29,93 +29,97 @@ class InstallCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('site:install')
-            ->setDescription($this->trans('commands.site.install.description'))
-            ->addArgument('profile', InputArgument::OPTIONAL, $this->trans('commands.site.install.arguments.profile'))
-            ->addOption(
-                'langcode',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.langcode')
-            )
-            ->addOption(
-                'db-type',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.db-type')
-            )
-            ->addOption(
-                'db-file',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.db-file')
-            )
-            ->addOption(
-                'db-host',
-                '',
-                InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.migrate.execute.options.db-host')
-            )
-            ->addOption(
-                'db-name',
-                '',
-                InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.migrate.execute.options.db-name')
-            )
-            ->addOption(
-                'db-user',
-                '',
-                InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.migrate.execute.options.db-user')
-            )
-            ->addOption(
-                'db-pass',
-                '',
-                InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.migrate.execute.options.db-pass')
-            )
-            ->addOption(
-                'db-prefix',
-                '',
-                InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.migrate.execute.options.db-prefix')
-            )
-            ->addOption(
-                'db-port',
-                '',
-                InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.migrate.execute.options.db-port')
-            )
-            ->addOption(
-                'site-name',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.site-name')
-            )
-            ->addOption(
-                'site-mail',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.site-mail')
-            )
-            ->addOption(
-                'account-name',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.account-name')
-            )
-            ->addOption(
-                'account-mail',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.account-mail')
-            )
-            ->addOption(
-                'account-pass',
-                '',
-                InputOption::VALUE_REQUIRED,
-                $this->trans('commands.site.install.arguments.account-pass')
-            );
+          ->setName('site:install')
+          ->setDescription($this->trans('commands.site.install.description'))
+          ->addArgument(
+            'profile',
+            InputArgument::OPTIONAL,
+            $this->trans('commands.site.install.arguments.profile')
+          )
+          ->addOption(
+            'langcode',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.langcode')
+          )
+          ->addOption(
+            'db-type',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.db-type')
+          )
+          ->addOption(
+            'db-file',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.db-file')
+          )
+          ->addOption(
+            'db-host',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.migrate.execute.options.db-host')
+          )
+          ->addOption(
+            'db-name',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.migrate.execute.options.db-name')
+          )
+          ->addOption(
+            'db-user',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.migrate.execute.options.db-user')
+          )
+          ->addOption(
+            'db-pass',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.migrate.execute.options.db-pass')
+          )
+          ->addOption(
+            'db-prefix',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.migrate.execute.options.db-prefix')
+          )
+          ->addOption(
+            'db-port',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            $this->trans('commands.migrate.execute.options.db-port')
+          )
+          ->addOption(
+            'site-name',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.site-name')
+          )
+          ->addOption(
+            'site-mail',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.site-mail')
+          )
+          ->addOption(
+            'account-name',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.account-name')
+          )
+          ->addOption(
+            'account-mail',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.account-mail')
+          )
+          ->addOption(
+            'account-pass',
+            '',
+            InputOption::VALUE_REQUIRED,
+            $this->trans('commands.site.install.arguments.account-pass')
+          );
     }
 
     /**
@@ -130,8 +134,8 @@ class InstallCommand extends Command
         if (!$profile) {
             $profiles = $this->getProfiles();
             $profile = $io->choice(
-                $this->trans('commands.site.install.questions.profile'),
-                array_values($profiles)
+              $this->trans('commands.site.install.questions.profile'),
+              array_values($profiles)
             );
             $input->setArgument('profile', array_search($profile, $profiles));
         }
@@ -143,9 +147,9 @@ class InstallCommand extends Command
             $defaultLanguage = $this->getDefaultLanguage();
 
             $langcode = $io->choiceNoList(
-                $this->trans('commands.site.install.questions.langcode'),
-                $languages,
-                $languages[$defaultLanguage]
+              $this->trans('commands.site.install.questions.langcode'),
+              $languages,
+              $languages[$defaultLanguage]
             );
 
             $input->setOption('langcode', $langcode);
@@ -168,7 +172,7 @@ class InstallCommand extends Command
                 $dbFile = $this->dbFileQuestion($io);
                 $input->setOption('db-file', $dbFile);
             }
-            if ($dbType != 'sqlite') {
+            elseif ($dbType != 'sqlite') {
                 // --db-host option
                 $dbHost = $input->getOption('db-host');
                 if (!$dbHost) {
@@ -211,7 +215,8 @@ class InstallCommand extends Command
                 $dbPrefix = $this->dbPrefixQuestion($io);
                 $input->setOption('db-prefix', $dbPrefix);
             }
-        } else {
+        }
+        else {
             $input->setOption('db-type', $database['default']['driver']);
             $input->setOption('db-host', $database['default']['host']);
             $input->setOption('db-name', $database['default']['database']);
@@ -220,12 +225,12 @@ class InstallCommand extends Command
             $input->setOption('db-port', $database['default']['port']);
             $input->setOption('db-prefix', $database['default']['prefix']['default']);
             $io->info(
-                sprintf(
-                    $this->trans('commands.site.install.messages.using-current-database'),
-                    $database['default']['driver'],
-                    $database['default']['database'],
-                    $database['default']['username']
-                )
+              sprintf(
+                $this->trans('commands.site.install.messages.using-current-database'),
+                $database['default']['driver'],
+                $database['default']['database'],
+                $database['default']['username']
+              )
             );
         }
 
@@ -233,8 +238,8 @@ class InstallCommand extends Command
         $site_name = $input->getOption('site-name');
         if (!$site_name) {
             $site_name = $io->ask(
-                $this->trans('commands.site.install.questions.site-name'),
-                'Drupal 8 Site Install'
+              $this->trans('commands.site.install.questions.site-name'),
+              'Drupal 8 Site Install'
             );
             $input->setOption('site-name', $site_name);
         }
@@ -243,8 +248,8 @@ class InstallCommand extends Command
         $site_mail = $input->getOption('site-mail');
         if (!$site_mail) {
             $site_mail = $io->ask(
-                $this->trans('commands.site.install.questions.site-mail'),
-                'admin@example.com'
+              $this->trans('commands.site.install.questions.site-mail'),
+              'admin@example.com'
             );
             $input->setOption('site-mail', $site_mail);
         }
@@ -253,8 +258,8 @@ class InstallCommand extends Command
         $account_name = $input->getOption('account-name');
         if (!$account_name) {
             $account_name = $io->ask(
-                $this->trans('commands.site.install.questions.account-name'),
-                'admin'
+              $this->trans('commands.site.install.questions.account-name'),
+              'admin'
             );
             $input->setOption('account-name', $account_name);
         }
@@ -263,8 +268,8 @@ class InstallCommand extends Command
         $account_mail = $input->getOption('account-mail');
         if (!$account_mail) {
             $account_mail = $io->ask(
-                $this->trans('commands.site.install.questions.account-mail'),
-                $site_mail
+              $this->trans('commands.site.install.questions.account-mail'),
+              $site_mail
             );
             $input->setOption('account-mail', $account_mail);
         }
@@ -273,61 +278,10 @@ class InstallCommand extends Command
         $account_pass = $input->getOption('account-pass');
         if (!$account_pass) {
             $account_pass = $io->askHidden(
-                $this->trans('commands.site.install.questions.account-pass')
+              $this->trans('commands.site.install.questions.account-pass')
             );
             $input->setOption('account-pass', $account_pass);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        $output = new DrupalStyle($input, $output);
-
-        // Database options
-        $dbType = $input->getOption('db-type');
-        $dbFile = $input->getOption('db-file');
-        $dbHost = $input->getOption('db-host');
-        $dbName = $input->getOption('db-name');
-        $dbUser = $input->getOption('db-user');
-        $dbPass = $input->getOption('db-pass');
-        $dbPrefix = $input->getOption('db-prefix');
-        $dbPort = $input->getOption('db-port');
-
-        $databases = $this->getDatabaseTypes();
-
-        if ($dbType == 'sqlite') {
-            $database = array(
-              'database' => $dbFile,
-              'prefix' => $dbPrefix,
-              'namespace' => $databases[$dbType]['namespace'],
-              'driver' => $dbType,
-            );
-        } else {
-            $database = array(
-              'database' => $dbName,
-              'username' => $dbUser,
-              'password' => $dbPass,
-              'prefix' => $dbPrefix,
-              'port' => $dbPort,
-              'host' => $dbHost,
-              'namespace' => $databases[$dbType]['namespace'],
-              'driver' => $dbType,
-            );
-        }
-
-        $this->backupSitesFile($output);
-
-        try {
-            $this->runInstaller($output, $input, $database);
-        } catch (Exception $e) {
-            $output->error($e->getMessage());
-            return;
-        }
-
-        $this->restoreSitesFile($output);
     }
 
     protected function getProfiles()
@@ -359,6 +313,58 @@ class InstallCommand extends Command
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output = new DrupalStyle($input, $output);
+
+        // Database options
+        $dbType = $input->getOption('db-type');
+        $dbFile = $input->getOption('db-file');
+        $dbHost = $input->getOption('db-host');
+        $dbName = $input->getOption('db-name');
+        $dbUser = $input->getOption('db-user');
+        $dbPass = $input->getOption('db-pass');
+        $dbPrefix = $input->getOption('db-prefix');
+        $dbPort = $input->getOption('db-port');
+
+        $databases = $this->getDatabaseTypes();
+
+        if ($dbType == 'sqlite') {
+            $database = [
+              'database' => $dbFile,
+              'prefix' => $dbPrefix,
+              'namespace' => $databases[$dbType]['namespace'],
+              'driver' => $dbType,
+            ];
+        }
+        else {
+            $database = [
+              'database' => $dbName,
+              'username' => $dbUser,
+              'password' => $dbPass,
+              'prefix' => $dbPrefix,
+              'port' => $dbPort,
+              'host' => $dbHost,
+              'namespace' => $databases[$dbType]['namespace'],
+              'driver' => $dbType,
+            ];
+        }
+
+        $this->backupSitesFile($output);
+
+        try {
+            $this->runInstaller($output, $input, $database);
+        } catch (Exception $e) {
+            $output->error($e->getMessage());
+            return NULL;
+        }
+
+        $this->restoreSitesFile($output);
+    }
+
+    /**
      * Backs up sites.php to backup.sites.php (if needed).
      *
      * This is needed because of a bug with install_drupal() that causes the
@@ -372,11 +378,67 @@ class InstallCommand extends Command
         $root = $this->get('site')->getRoot();
 
         if (!file_exists($root . '/sites/sites.php')) {
-            return;
+            return NULL;
         }
 
         rename($root . '/sites/sites.php', $root . '/sites/backup.sites.php');
         $output->info($this->trans('commands.site.install.messages.sites-backup'));
+    }
+
+    protected function runInstaller(
+      DrupalStyle $output,
+      InputInterface $input,
+      $database
+    ) {
+        $drupal = $this->get('site');
+        $drupal->loadLegacyFile('/core/includes/install.core.inc');
+
+        $driver = (string) $database['driver'];
+        $settings = [
+          'parameters' => [
+            'profile' => $input->getArgument('profile'),
+            'langcode' => $input->getOption('langcode'),
+          ],
+          'forms' => [
+            'install_settings_form' => [
+              'driver' => $driver,
+              $driver => $database,
+              'op' => 'Save and continue',
+            ],
+            'install_configure_form' => [
+              'site_name' => $input->getOption('site-name'),
+              'site_mail' => $input->getOption('site-mail'),
+              'account' => [
+                'name' => $input->getOption('account-name'),
+                'mail' => $input->getOption('account-mail'),
+                'pass' => [
+                  'pass1' => $input->getOption('account-pass'),
+                  'pass2' => $input->getOption('account-pass')
+                ],
+              ],
+              'update_status_module' => [
+                1 => TRUE,
+                2 => TRUE,
+              ],
+              'clean_url' =>  TRUE,
+              'op' => 'Save and continue',
+            ],
+          ]
+        ];
+
+        $output->info($this->trans('commands.site.install.messages.installing'));
+
+        try {
+            install_drupal($drupal->getAutoLoadClass(), $settings);
+        } catch (AlreadyInstalledException $e) {
+            $output->error($this->trans('commands.site.install.messages.already-installed'));
+            return NULL;
+        } catch (\Exception $e) {
+            $output->error($e->getMessage());
+            return NULL;
+        }
+
+        $output->success($this->trans('commands.site.install.messages.installed'));
     }
 
     /**
@@ -389,66 +451,10 @@ class InstallCommand extends Command
         $root = $this->get('site')->getRoot();
 
         if (!file_exists($root . '/sites/backup.sites.php')) {
-            return;
+            return NULL;
         }
 
         rename($root . '/sites/backup.sites.php', $root . '/sites/sites.php');
         $output->info($this->trans('commands.site.install.messages.sites-restore'));
-    }
-
-    protected function runInstaller(
-        DrupalStyle $output,
-        InputInterface $input,
-        $database
-    ) {
-        $drupal = $this->get('site');
-        $drupal->loadLegacyFile('/core/includes/install.core.inc');
-
-        $driver = (string) $database['driver'];
-        $settings = [
-            'parameters' => [
-                'profile' => $input->getArgument('profile'),
-                'langcode' => $input->getOption('langcode'),
-            ],
-            'forms' => [
-                'install_settings_form' => [
-                    'driver' => $driver,
-                    $driver => $database,
-                    'op' => 'Save and continue',
-                ],
-                'install_configure_form' => [
-                    'site_name' => $input->getOption('site-name'),
-                    'site_mail' => $input->getOption('site-mail'),
-                    'account' => array(
-                        'name' => $input->getOption('account-name'),
-                        'mail' => $input->getOption('account-mail'),
-                        'pass' => array(
-                            'pass1' => $input->getOption('account-pass'),
-                            'pass2' => $input->getOption('account-pass')
-                        ),
-                    ),
-                    'update_status_module' => array(
-                        1 => true,
-                        2 => true,
-                    ),
-                    'clean_url' =>  true,
-                    'op' => 'Save and continue',
-                ],
-            ]
-        ];
-
-        $output->info($this->trans('commands.site.install.messages.installing'));
-
-        try {
-            install_drupal($drupal->getAutoLoadClass(), $settings);
-        } catch (AlreadyInstalledException $e) {
-            $output->error($this->trans('commands.site.install.messages.already-installed'));
-            return;
-        } catch (\Exception $e) {
-            $output->error($e->getMessage());
-            return;
-        }
-
-        $output->success($this->trans('commands.site.install.messages.installed'));
     }
 }


### PR DESCRIPTION
### Description
At the moment site:install only works on fresh sites, after that is painful execute this command.

With drush you can execute site install as many times as you want and you don't even need create the table (brilliant for lazy people/beginners) I think this is the normal behavior, when you execute site:install you want to install it, check if the table exist, or if is a new site, etc...
For check all that other things, you can use a database user without permissions, or execute site:status/debug, etc...

Maybe we can keep this behavior with the parameter `--safe-install` or something like that?
Issue: #2269 

### Additional info

Maybe requires big changes like update `src/Helper/KernelHerlper.php`