### PR TITLE
[migrate:*] Updated commands to process migrations

### DIFF
--- a/config/services/migrate.yml
+++ b/config/services/migrate.yml
@@ -1,5 +1,9 @@
 services:
-  migrate_setup:
-    class: Drupal\Console\Command\Migrate\SetupCommand
+  migrate_execute:
+    class: Drupal\Console\Command\Migrate\ExecuteCommand
+    tags:
+      - { name: console.command }
+  migrate_debug:
+    class: Drupal\Console\Command\Migrate\DebugCommand
     tags:
       - { name: console.command }

--- a/src/Command/ContainerAwareCommand.php
+++ b/src/Command/ContainerAwareCommand.php
@@ -36,41 +36,6 @@ abstract class ContainerAwareCommand extends Command
         return $this->getKernelHelper()->getKernel()->getContainer();
     }
 
-    /**
-     * @param bool $tag
-     * @param bool $flatList
-     *
-     * @return array list of modules
-     */
-    public function getMigrations($tag = false, $flatList = false)
-    {
-        $entityType_manager = $this->getService('entity_type.manager');
-        $migration_storage = $entityType_manager->getStorage('migration');
-
-        $entity_query_service = $this->getEntityQuery();
-        $query = $entity_query_service->get('migration');
-
-        if ($tag) {
-            $query->condition('migration_tags.*', $tag);
-        }
-
-        $results = $query->execute();
-
-        $migration_entities = $migration_storage->loadMultiple($results);
-
-        $migrations = array();
-        foreach ($migration_entities as $migration) {
-            if ($flatList) {
-                $migrations[$migration->id()] = ucwords($migration->label());
-            } else {
-                $migrations[$migration->id()]['tags'] = implode(', ', $migration->migration_tags);
-                $migrations[$migration->id()]['description'] = ucwords($migration->label());
-            }
-        }
-
-        return $migrations;
-    }
-
     public function getRestDrupalConfig()
     {
         $configFactory = $this->getConfigFactory();

--- a/src/Command/Migrate/DebugCommand.php
+++ b/src/Command/Migrate/DebugCommand.php
@@ -10,9 +10,11 @@ namespace Drupal\Console\Command\Migrate;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\Console\Command\ContainerAwareCommand;
+use Drupal\Console\Command\Shared\MigrationTrait;
 use Drupal\Console\Style\DrupalStyle;
 use Drupal\Console\Annotation\DrupalCommand;
+use Symfony\Component\Console\Command\Command;
+use Drupal\Console\Command\Shared\ContainerAwareCommandTrait;
 
 /**
  * @DrupalCommand(
@@ -21,8 +23,11 @@ use Drupal\Console\Annotation\DrupalCommand;
  *     }
  * )
  */
-class DebugCommand extends ContainerAwareCommand
-{
+class DebugCommand extends Command
+{   
+    use MigrationTrait;
+    use ContainerAwareCommandTrait;
+
     protected function configure()
     {
         $this
@@ -33,16 +38,15 @@ class DebugCommand extends ContainerAwareCommand
                 InputArgument::OPTIONAL,
                 $this->trans('commands.migrate.debug.arguments.tag')
             );
-
-        $this->addDependency('migrate');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new DrupalStyle($input, $output);
-        $drupal_version = $input->getArgument('tag');
-
+        $drupal_version = 'Drupal ' . $input->getArgument('tag');
+        
         $migrations = $this->getMigrations($drupal_version);
+        
 
         $tableHeader = [
           $this->trans('commands.migrate.debug.messages.id'),

--- a/src/Command/Migrate/SetupCommand.php
+++ b/src/Command/Migrate/SetupCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command;
 use Drupal\Console\Command\Shared\ContainerAwareCommandTrait;
 use Drupal\Console\Command\Shared\DatabaseTrait;
-use Drupal\migrate\Entity\Migration;
+use Drupal\Console\Command\Shared\MigrationTrait;
 use Drupal\migrate\Plugin\RequirementsInterface;
 use Drupal\migrate\Exception\RequirementsException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
@@ -23,6 +23,7 @@ class SetupCommand extends Command
 {
     use ContainerAwareCommandTrait;
     use DatabaseTrait;
+    use MigrationTrait;
 
     protected function configure()
     {
@@ -89,7 +90,7 @@ class SetupCommand extends Command
         // --db-type option
         $db_type = $input->getOption('db-type');
         if (!$db_type) {
-            $db_type = $this->dbTypeQuestion($output);
+            $db_type = $this->dbDriverTypeQuestion($output);
             $input->setOption('db-type', $db_type);
         }
 
@@ -149,89 +150,25 @@ class SetupCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new DrupalStyle($input, $output);
-        $template_storage = $this->getDrupalService('migrate.template_storage');
-        $source_base_path = $input->getOption('files-directory');
+       
 
         $this->registerMigrateDB($input, $output);
-        $migrateConnection = $this->getDBConnection($io, 'default', 'migrate');
+        $this->migrateConnection = $this->getDBConnection($output,'default','upgrade');
 
-        if (!$drupal_version = $this->getLegacyDrupalVersion($migrateConnection)) {
-            $io->error($this->trans('commands.migrate.setup.questions.not-drupal'));
-
-            return 1;
+        if (!$drupal_version = $this->getLegacyDrupalVersion($this->migrateConnection)) {
+            $io->error($this->trans('commands.migrate.setup.migrations.questions.not-drupal'));
+            return;
         }
-
-        $database_state['key'] = 'upgrade';
-        $database_state['database'] = $this->getDBInfo();
-        $database_state_key = 'migrate_upgrade_' . $drupal_version;
-
-        \Drupal::state()->set($database_state_key, $database_state);
-
+        
+        $database = $this->getDBInfo();
         $version_tag = 'Drupal ' . $drupal_version;
-
-        $migration_templates = $template_storage->findTemplatesByTag($version_tag);
-
-        $builderManager = $this->getDrupalService('migrate.migration_builder');
-        foreach ($migration_templates as $id => $template) {
-            $migration_templates[$id]['source']['database_state_key'] = $database_state_key;
-            // Configure file migrations so they can find the files.
-            if ($template['destination']['plugin'] == 'entity:file') {
-                if ($source_base_path) {
-                    // Make sure we have a single trailing slash.
-                    $source_base_path = rtrim($source_base_path, '/') . '/';
-                    $migration_templates[$id]['destination']['source_base_path'] = $source_base_path;
-                }
-            }
-        }
-
-        // Let the builder service create our migration configuration entities from
-        // the templates, expanding them to multiple entities where necessary.
-        /**
-         * @var \Drupal\migrate\MigrationBuilder $builder
-         */
-        $migrations = $builderManager->createMigrations($migration_templates);
-        foreach ($migrations as $migration) {
-            try {
-                if ($migration->getSourcePlugin() instanceof RequirementsInterface) {
-                    $migration->getSourcePlugin()->checkRequirements();
-                }
-                if ($migration->getDestinationPlugin() instanceof RequirementsInterface) {
-                    $migration->getDestinationPlugin()->checkRequirements();
-                }
-                // Don't try to resave migrations that already exist.
-                if (!Migration::load($migration->id())) {
-                    $migration->save();
-                    $migration_ids[] = $migration->id();
-                }
-            }
-            // Migrations which are not applicable given the source and destination
-            // site configurations (e.g., what modules are enabled) will be silently
-            // ignored.
-            catch (RequirementsException $e) {
-                $io->error($e->getMessage());
-            } catch (PluginNotFoundException $e) {
-                $io->error($e->getMessage());
-            }
-        }
-
-        if (empty($migration_ids)) {
-            if (empty($migrations)) {
-                $io->info(
-                    sprintf(
-                        $this->trans('commands.migrate.setup.messages.migrations-not-found'),
-                        count($migrations)
-                    )
-                );
-            } else {
-                $io->error(
-                    sprintf(
-                        $this->trans('commands.migrate.setup.messages.migrations-already-exist'),
-                        count($migrations)
-                    )
-                );
-            }
-        } else {
-            $io->info(
+        
+        $this->createDatabaseStateSettings($database,$drupal_version);
+        
+        $migrations  = $this->getMigrations($version_tag);
+        
+        if ($migrations) {
+             $io->info(
                 sprintf(
                     $this->trans('commands.migrate.setup.messages.migrations-created'),
                     count($migrations),
@@ -239,5 +176,6 @@ class SetupCommand extends Command
                 )
             );
         }
+
     }
 }

--- a/src/Command/Shared/MigrationTrait.php
+++ b/src/Command/Shared/MigrationTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Console\Command\Shared\MigrationTrait.
+ */
+
+namespace Drupal\Console\Command\Shared;
+
+/**
+ * Class MigrationTrait
+ * @package Drupal\Console\Command
+ */
+trait MigrationTrait
+{
+     
+    /**
+     * @param bool $version_tag
+     * @param bool $flatList
+     *
+     * @return array list of migrations
+     */
+    protected function getMigrations($version_tag = false, $flatList = false)
+    {   
+        $plugin_manager = $this->getDrupalService('plugin.manager.migration');
+        $all_migrations = $plugin_manager->createInstancesByTag($version_tag);
+ 
+        $migrations = array();
+        foreach ($all_migrations as $migration) {
+            if ($flatList) {
+                $migrations[$migration->id()] = ucwords($migration->label());
+            } else {
+                $migrations[$migration->id()]['tags'] = implode(', ', $migration->migration_tags);
+                $migrations[$migration->id()]['description'] = ucwords($migration->label());
+            }
+        }
+        
+        return  $migrations;
+    }
+
+    protected function createDatabaseStateSettings(array $database, $drupal_version)
+    {
+        $database_state['key'] = 'upgrade';
+        $database_state['database'] = $database;
+        $database_state_key = 'migrate_drupal_' . $drupal_version;
+
+        $state_service = $this->getDrupalService('state');
+        $state_service->set($database_state_key, $database_state);
+        $state_service->set('migrate.fallback_state_key', $database_state_key);
+    }
+
+     /**
+     * @return mixed
+     */
+    protected function getDatabaseDrivers()
+    {    
+        // Make sure the install API is available.
+        include_once DRUPAL_ROOT . '/core/includes/install.inc';
+        return drupal_get_database_types();
+
+    }
+
+}


### PR DESCRIPTION
List of changes: 

- Now we are using plugins to get a  list of migrations ids 
I removed the method getMigrations() from src/Command/ContainerAwareCommand.php and I moved it to a new Trait called MigrationTraid. 

  We load migrations using this:
 `$plugin_manager = $this->getDrupalService('plugin.manager.migration');
  $all_migrations = $plugin_manager->createInstancesByTag($version_tag);`

- To get those migrations we must to set up the database settings, so I made some changes to command migrate:setup
 This command now only load the database configuration  , so I removed the code which generate templates. 

- In order to get the dbTypes now we are calling the function directly from the core with:
 `include_once DRUPAL_ROOT . '/core/includes/install.inc';
  return drupal_get_database_types();`

- To execute a migration  , we create instances using the plugins
`$migration_service = $this->getDrupalService('plugin.manager.migration');        
  $migration_service = $migration_service->createInstance($migration_id);`

- Note: To get a list of migrations , just run drupal migrate:debug and you are going to a get the full list , so if you want filter that list , try with drupal migrate:debug 7 or drupal migrate:debug 6

