### PR TITLE
[generate:plugin:fieldwidget] Do not override field widget form element

### DIFF
--- a/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
+++ b/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
@@ -84,8 +84,6 @@ class {{ class_name }} extends WidgetBase {% endblock %}
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    $element = [];
-
     $element['value'] = $element + [
       '#type' => 'textfield',
       '#default_value' => isset($items[$delta]->value) ? $items[$delta]->value : NULL,


### PR DESCRIPTION
*Problem/Motivation*

A generated widget will not reflect basic properties of the field e.g. display label or description.

*How to reproduce*

Run `drupal generate:plugin:fieldwidget`. Subsequent input should not matter in this regard.

*Solution*

`formElement()` accepts an `$element` argument. This contains basic properties such as title, description and whether the value is required.

In the current template this argument is overridden with an empty array. As I see it there is no reason to override the variable.