### PR TITLE
Do not reset $element in formElement for FieldWidget

### DIFF
--- a/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
+++ b/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
@@ -84,8 +84,6 @@ class {{ class_name }} extends WidgetBase {% endblock %}
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    $element = [];
-
     $element['value'] = $element + array(
       '#type' => 'textfield',
       '#default_value' => isset($items[$delta]->value) ? $items[$delta]->value : NULL,


### PR DESCRIPTION
The $element array has #title, #title_display and #description values. `$element = [];` removes these.