### PR TITLE
support Git Bash on windows

### DIFF
--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -85,7 +85,9 @@ class ServerCommand extends BaseCommand
         $processBuilder = new ProcessBuilder(explode(' ', $cli));
         $process = $processBuilder->getProcess();
         $process->setWorkingDirectory($this->get('site')->getRoot());
-        $process->setTty('true');
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            $process->setTty('true');
+        }
         $process->run();
 
         if (!$process->isSuccessful()) {

--- a/src/Command/Shared/ProjectDownloadTrait.php
+++ b/src/Command/Shared/ProjectDownloadTrait.php
@@ -8,7 +8,11 @@
 namespace Drupal\Console\Command\Shared;
 
 use Drupal\Console\Style\DrupalStyle;
+use Drupal\Console\Zippy\Adapter\TarGzGNUTarForWindowsAdapter;
+use Drupal\Console\Zippy\FileStrategy\TarGzFileForWindowsStrategy;
 use Alchemy\Zippy\Zippy;
+use Alchemy\Zippy\Adapter\AdapterContainer;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Class ProjectDownloadTrait
@@ -187,8 +191,32 @@ trait ProjectDownloadTrait
             }
 
             $zippy = Zippy::load();
+            if (PHP_OS === "WIN32" || PHP_OS === "WINNT") {
+                $container = AdapterContainer::load();
+                $container['Drupal\\Console\\Zippy\\Adapter\\TarGzGNUTarForWindowsAdapter'] = function($container) {
+                    return TarGzGNUTarForWindowsAdapter::newInstance(
+                        $container['executable-finder'],
+                        $container['resource-manager'],
+                        $container['gnu-tar.inflator'],
+                        $container['gnu-tar.deflator']
+                    );
+                };
+                $zippy->addStrategy(new TarGzFileForWindowsStrategy($container));
+            }
             $archive = $zippy->open($destination);
-            $archive->extract($projectPath);
+            if ($type == 'core') {
+                $archive->extract(getenv('MSYSTEM') ? NULL : $projectPath);
+            } else if (getenv('MSYSTEM')) {
+                $current_dir = getcwd();
+                $temp_dir = sys_get_temp_dir();
+                chdir($temp_dir);
+                $archive->extract();
+                $fileSystem = new Filesystem();
+                $fileSystem->rename($temp_dir . '/' . $project, $projectPath . '/' . $project);
+                chdir($current_dir);
+            } else {
+                $archive->extract($projectPath);
+            }
 
             unlink($destination);
 

--- a/src/Zippy/Adapter/TarGzGNUTarForWindowsAdapter.php
+++ b/src/Zippy/Adapter/TarGzGNUTarForWindowsAdapter.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Console\Zippy\Adapter\TarGzGNUTarForWindowsAdapter.
+ */
+
+namespace Drupal\Console\Zippy\Adapter;
+
+use Alchemy\Zippy\Adapter\GNUTar\TarGzGNUTarAdapter;
+use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
+use Alchemy\Zippy\Exception\NotSupportedException;
+
+/**
+ * Class TarGzGNUTarForWindowsAdapter
+ * @package Drupal\Console\Zippy\Adapter
+ */
+class TarGzGNUTarForWindowsAdapter extends TarGzGNUTarAdapter
+{
+
+    /**
+     * @inheritdoc
+     */
+    protected function doAdd(ResourceInterface $resource, $files, $recursive)
+    {
+        throw new NotSupportedException('Updating a compressed tar archive is not supported.');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getLocalOptions()
+    {
+        return array_merge(parent::getLocalOptions(), array('--force-local'));
+    }
+}

--- a/src/Zippy/FileStrategy/TarGzFileForWindowsStrategy.php
+++ b/src/Zippy/FileStrategy/TarGzFileForWindowsStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Console\Zippy\Strategy\ProjectDownloadTrait.
+ */
+
+namespace Drupal\Console\Zippy\FileStrategy;
+
+use Alchemy\Zippy\FileStrategy\AbstractFileStrategy;
+
+/**
+ * Class TarGzFileForWindowsStrategy
+ * @package Drupal\Console\Zippy/Strategy
+ */
+class TarGzFileForWindowsStrategy extends AbstractFileStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getServiceNames()
+    {
+        return array(
+            'Drupal\\Console\\Zippy\\Adapter\\TarGzGNUTarForWindowsAdapter'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFileExtension()
+    {
+        return 'tar.gz';
+    }
+}


### PR DESCRIPTION
In https://hechoendrupal.gitbooks.io/drupal-console/content/en/getting/windows.html, 
"Git Bash" is recommended for Windows environment.

But installation with "quick-start" (```drupal chain --file="C:\Users\{user}\.console\chain\quick-start.yml"```) failed because it has some error regarding path style.

this problem is reported at #2214 .