### PR TITLE
Fix #2130 Do not check for mysql and sqlite3 extension

### DIFF
--- a/config/dist/phpcheck.yml
+++ b/config/dist/phpcheck.yml
@@ -23,5 +23,4 @@ requirements:
       - xml
       - curl
     recommended:
-      - mysql
       - sqlite3

--- a/config/dist/phpcheck.yml
+++ b/config/dist/phpcheck.yml
@@ -23,4 +23,3 @@ requirements:
       - xml
       - curl
     recommended:
-      - sqlite3


### PR DESCRIPTION
This extension has been removed in PHP7 and the error message is misleading.