### PR TITLE
#1991 - Alternative exiting of form creation

### DIFF
--- a/config/translations/en/common.yml
+++ b/config/translations/en/common.yml
@@ -23,7 +23,7 @@ questions:
         label: 'Input label'
         machine_name: 'Input machine name'
         permission: 'Do you want to generate permissions?'
-        type: Type
+        type: 'New field type (press <return> to stop adding fields)'
         invalid: 'Field Type "%s" is invalid.'
         description: Description
         default-value:


### PR DESCRIPTION
### Before
<img width="444" alt="screen shot 2016-07-30 at 16 00 26" src="https://cloud.githubusercontent.com/assets/1220029/17271270/ecc410c8-566e-11e6-9bdf-6c69e85b7fad.png">
### After
<img width="459" alt="screen shot 2016-07-30 at 16 00 12" src="https://cloud.githubusercontent.com/assets/1220029/17271269/ecc3b768-566e-11e6-95db-635b13b7b5e4.png">
