### PR TITLE
#1959 Show Info that the missing configuration is a php-configuration.

### DIFF
--- a/config/translations/en/check.yml
+++ b/config/translations/en/check.yml
@@ -2,7 +2,7 @@ description: 'System requirement checker'
 messages:
   php_invalid: 'The current installed version "%s" is invalid, it requires "%s" or higher'
   configuration_missing: 'The configuration "%s" is missing.'
-  configuration_overwritten: 'The configuration "%s" was missing and overwritten with "%s".'
+  configuration_overwritten: 'The PHP-Configuration (php.ini) "%s" was missing and overwritten with "%s".'
   extension_missing: 'The extension "%s" is missing.'
   extension_recommended: 'The extension "%s" is recommended to install.'
   success: 'Checks passed.'


### PR DESCRIPTION
Today i stumpled upon issue #1959 with the missing time zone configuration and at first I thought a drupal configurations is meant because the message came up when I issued drupal config:diff in the terminal. Here is my idea to save other people some time.