### PR TITLE
prevent timeout of server process on windows

### DIFF
--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -87,6 +87,8 @@ class ServerCommand extends BaseCommand
         $process->setWorkingDirectory($this->get('site')->getRoot());
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
             $process->setTty('true');
+        } else {
+            $process->setTimeout(null);
         }
         $process->run();
 


### PR DESCRIPTION
On windows, server command is timeout every 60 seconds.

![drupalconsole_timedout_windows](https://cloud.githubusercontent.com/assets/175681/17439784/a3c1fee4-5b64-11e6-8c81-714133c2b262.png)
