### PR TITLE
[#2634] Ensure link menu definition starts on a new line.

### DIFF
--- a/templates/module/links.menu-entity-config.yml.twig
+++ b/templates/module/links.menu-entity-config.yml.twig
@@ -1,3 +1,5 @@
+{# Initial new line ensures that the new definitions starts on a new line #}
+
 # {{ label }} menu items definition
 entity.{{ entity_name }}.collection:
   title: '{{ label }}'

--- a/templates/module/links.menu-entity-content.yml.twig
+++ b/templates/module/links.menu-entity-content.yml.twig
@@ -1,3 +1,5 @@
+{# Initial new line ensures that the new definitions starts on a new line #}
+
 # {{ label }} menu items definition
 entity.{{ entity_name }}.collection:
   title: '{{ label }} list'


### PR DESCRIPTION
This pull request fixes the problem I was having in 

https://github.com/hechoendrupal/DrupalConsole/issues/2634