### PR TITLE
Error in: drupal generate:form:alter.

### DIFF
--- a/templates/module/src/Form/form-alter.php.twig
+++ b/templates/module/src/Form/form-alter.php.twig
@@ -55,9 +55,9 @@ function {{ module }}_form_alter(&$form, FormStateInterface $form_state, $form_i
         ];
 
 {% endfor %}
-{% if form_id == '' %}
-    }
 {% endif %}
+{% if form_id is empty %}
+    }
 {% endif %}
 }
 {% endblock %}


### PR DESCRIPTION
No exist a last close bracket, in form_id validation. execute command with default values.