### PR TITLE
[container:parameters] Issue #2766: add a container:parameters command.

### DIFF
--- a/config/services/drupal-console/misc.yml
+++ b/config/services/drupal-console/misc.yml
@@ -3,6 +3,10 @@ services:
     class: Drupal\Console\Command\ContainerDebugCommand
     tags:
       - { name: drupal.command }
+  console.parameters_debug:
+    class: Drupal\Console\Command\ContainerParametersCommand
+    tags:
+      - { name: drupal.command }
   console.plugin_debug:
     class: Drupal\Console\Command\PluginDebugCommand
     tags:

--- a/src/Command/ContainerParametersCommand.php
+++ b/src/Command/ContainerParametersCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\ContainerParametersCommand.
+ */
+
+namespace Drupal\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
+use Drupal\Console\Command\Shared\ContainerAwareCommandTrait;
+use Drupal\Console\Style\DrupalStyle;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Class ContainerParametersCommand
+ *
+ * @package Drupal\Console\Command
+ */
+class ContainerParametersCommand extends Command {
+  use ContainerAwareCommandTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this
+      ->setName('container:parameters')
+      ->setDescription($this->trans('commands.container.parameters.description'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $io = new DrupalStyle($input, $output);
+
+    $parametersList = $this->getParametersList();
+    ksort($parametersList);
+    $parameters = ['parameters' => $parametersList];
+    $io->write(Yaml::dump($parameters, 4, 2));
+    return 0;
+  }
+
+  private function getParametersList() {
+    $parameters = array_filter($this->container->getParameterBag()->all(), function ($name) {
+      if (preg_match('/^container\./', $name)) {
+        return FALSE;
+      }
+      if (preg_match('/^drupal\./', $name)) {
+        return FALSE;
+      }
+      if (preg_match('/^console\./', $name)) {
+        return FALSE;
+      }
+      return TRUE;
+    }, ARRAY_FILTER_USE_KEY);
+
+    return $parameters;
+  }
+
+}


### PR DESCRIPTION
Suggested content for console-en / translations / container.parameters.yml:

description: 'Displays current parameters for an application. Internal parameters of Drupal, Console, and the container are excluded for readability.'
