### PR TITLE
Fix #2759 use single quote to surround service names in YML files

### DIFF
--- a/src/Helper/TwigRendererHelper.php
+++ b/src/Helper/TwigRendererHelper.php
@@ -103,7 +103,7 @@ class TwigRendererHelper extends Helper
             'servicesAsParametersKeys', function ($services) {
                 $returnValues = [];
                 foreach ($services as $service) {
-                    $returnValues[] = sprintf('"@%s"', $service['name']);
+                    $returnValues[] = sprintf('\'@%s\'', $service['name']);
                 }
 
                 return $returnValues;


### PR DESCRIPTION
Hopefully this will fix issue #2759 by using single quote instead of double quotes.