### PR TITLE
Fix incorrect validation call

### DIFF
--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -290,7 +290,7 @@ class ModuleCommand extends Command
 
         try {
             $machineName = $input->getOption('machine-name') ?
-              $this->validateModule(
+              $this->validate->validateModule(
                   $input->getOption('machine-name')
               ) : null;
         } catch (\Exception $error) {


### PR DESCRIPTION
Only triggered if --machine-name is used in the module:generate call.
see also #2801 and #2802