### PR TITLE
[generate:entity:content] The entity-content template must use ContentEntityBase.

### DIFF
--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -14,7 +14,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 {% if revisionable %}
 use Drupal\Core\Entity\RevisionableContentEntityBase;
 {% else %}
-use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\ContentEntityBase;
 {% endif %}
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;


### PR DESCRIPTION
In entity-content template ContentEntityBase must be used instead of ContentEntityInterface.

To reproduce:
Just 'drupal generate:entity:content' and choose to NOT enable revision
