### PR TITLE
PR for #2845

### DIFF
--- a/src/Command/Module/DownloadCommand.php
+++ b/src/Command/Module/DownloadCommand.php
@@ -185,7 +185,11 @@ class DownloadCommand extends Command
                         return 1;
                     } else {
                         $version = $io->choice(
-                            $this->trans('commands.site.new.questions.composer-release'),
+                            sprintf(
+																$this->trans(
+																		'commands.site.new.questions.composer-release'),
+																		$module
+																),
                             $versions
                         );
                     }


### PR DESCRIPTION
«Please, choose a 'module_name' version» 
instead of 
«Please, choose a… Packagist Drupal version»
