### PR TITLE
EntityContentGenearator should store *.page.inc in module root direct…

### DIFF
--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -167,7 +167,7 @@ class EntityContentGenerator extends Generator
 
         $this->renderFile(
             'module/entity-content-page.php.twig',
-            $this->extensionManager->getModule($module)->getSourcePath().'/'.$entity_name.'.page.inc',
+            $this->extensionManager->getModule($module)->getPath().'/'.$entity_name.'.page.inc',
             $parameters
         );
 


### PR DESCRIPTION
…ory, not /src

This patch puts the *.page.inc file in the module root directory, which is where hook_theme (@see entity-content.theme.php.twig) expects it to be.
