### PR TITLE
Fix msg for module:uninstall with dependencies.

### DIFF
--- a/src/Command/Module/UninstallCommand.php
+++ b/src/Command/Module/UninstallCommand.php
@@ -173,7 +173,7 @@ class UninstallCommand extends Command
                 $io->error(
                     sprintf(
                         $this->trans('commands.module.uninstall.messages.dependents'),
-                        implode(', ', $module),
+                        implode('", "', $moduleList),
                         implode(', ', $dependencies)
                     )
                 );


### PR DESCRIPTION
Currently if you run module:uninstall with f.e. comment and node, it will print this helpful message:
`[ERROR] Unable to uninstall modules "" because are required by "standard"`
this is because the module variable is null
if fixed to correctly implode the moduleList variable it'll print
`[ERROR] Unable to uninstall modules "comment, node" because are required by "standard, history, taxonomy, standard"`
but `[ERROR] Unable to uninstall modules "comment", "node" because are required by "standard, history, taxonomy, standard"` is better.
