### PR TITLE
added --gz option to database:dump

### DIFF
--- a/src/Command/Database/DumpCommand.php
+++ b/src/Command/Database/DumpCommand.php
@@ -63,6 +63,12 @@ class DumpCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.dump.option.file')
             )
+            ->addOption(
+                'gz',
+                false,
+                InputOption::VALUE_NONE,
+                $this->trans('commands.database.dump.option.gz')
+            )
             ->setHelp($this->trans('commands.database.dump.help'));
     }
 
@@ -76,6 +82,7 @@ class DumpCommand extends Command
         $database = $input->getArgument('database');
         $file = $input->getOption('file');
         $learning = $input->getOption('learning');
+        $gz = $input->getOption('gz');
 
         $databaseConnection = $this->resolveConnection($io, $database);
 
@@ -118,11 +125,24 @@ class DumpCommand extends Command
         }
 
         if ($this->shellProcess->exec($command, $this->appRoot)) {
+						$resultFile = $file;
+						if ($gz) {
+							$resultFile = $file . ".gz";
+							file_put_contents(
+									$resultFile,
+									gzencode(
+											file_get_contents(
+													$file)
+									)
+							);
+							unlink($file);
+						}
+
             $io->success(
                 sprintf(
                     '%s %s',
                     $this->trans('commands.database.dump.messages.success'),
-                    $file
+                    $resultFile
                 )
             );
         }


### PR DESCRIPTION
PR for #2862

i preferred to use native php functions for gzipping the file rather than using Drupal ArchiveTar class.
i did

``` php
file_put_contents(
  $resultFile,
    gzencode(
        file_get_contents(
            $file
            )
    )
);
```

perhaps you don't like it :upside_down_face: 
