### PR TITLE
Do not add ".processor" to end of plugin manager service name

### DIFF
--- a/templates/module/plugin-annotation-services.yml.twig
+++ b/templates/module/plugin-annotation-services.yml.twig
@@ -1,6 +1,6 @@
 {% if not file_exists %}
 services:
 {% endif %}
-  plugin.manager.{{ machine_name | lower }}.processor:
+  plugin.manager.{{ machine_name | lower }}:
     class: Drupal\{{ module }}\Plugin\{{ class_name }}Manager
     parent: default_plugin_manager


### PR DESCRIPTION
When generating a new annotation based plugin type the resulting services.yml looks like this:

```yaml
services:
  plugin.manager.sandwich_plugin_manager.processor:
    class: Drupal\sandwich\Plugin\SandwichPluginManagerManager
    parent: default_plugin_manager

```

Best practices for plugin manager service name are to prefix the service with `plugin.manager.` and then the name of the service. The addition of the `.processor` suffix here is kind of strange.

Contrast this with these definitions for core.services.yml, none of which have the .processor suffix.

```yaml
 plugin.manager.entity_reference_selection:
    class: Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManager
    parent: default_plugin_manager
  plugin.manager.block:
    class: Drupal\Core\Block\BlockManager
    parent: default_plugin_manager
  plugin.manager.field.field_type:
    class: Drupal\Core\Field\FieldTypePluginManager
    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@typed_data_manager']
  plugin.manager.field.widget:
    class: Drupal\Core\Field\WidgetPluginManager
    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@plugin.manager.field.field_type']
  plugin.manager.field.formatter:
    class: Drupal\Core\Field\FormatterPluginManager
    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@plugin.manager.field.field_type']
```

This pull request removes the unnecessary `.process` suffix.