### PR TITLE
Declare data_table in annotation only if entity is translatable

### DIFF
--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -56,7 +56,9 @@ use Drupal\user\UserInterface;
  *     },
  *   },
  *   base_table = "{{ entity_name }}",
+{% if is_translatable %}
  *   data_table = "{{ entity_name }}_field_data",
+{% endif %}
 {% if revisionable %}
  *   revision_table = "{{ entity_name }}_revision",
  *   revision_data_table = "{{ entity_name }}_field_revision",


### PR DESCRIPTION
If you generate a entity that is not translatable dont define "data_table" annotation because of side effects with views.

See for data_table implementaion @ https://www.drupal.org/node/1498674