### PR TITLE
Fixes wrong template path on generate:entity:content

### DIFF
--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -111,6 +111,6 @@ class Extension extends BaseExtension
      */
     public function getTemplatePath($fullPath = false)
     {
-        return $this->getSourcePath($fullPath) . '/templates';
+        return $this->getPath($fullPath) . '/templates';
     }
 }


### PR DESCRIPTION
After generate of a entity the templates files should be in MODULENAME/templates not in MODULENAME/src/templates this causes a exception on entity view.
