### PR TITLE
Conventions for Test classes and its Data Providers.

### DIFF
--- a/Test/Command/Generate/AuthenticationProviderCommandTest.php
+++ b/Test/Command/Generate/AuthenticationProviderCommandTest.php
@@ -4,15 +4,16 @@
  * Contains \Drupal\Console\Test\Command\GeneratorAuthenticationProviderCommandTest.
  */
 
-namespace Drupal\Console\Test\Command;
+namespace Drupal\Console\Test\Command\Generate;
 
 use Drupal\Console\Command\Generate\AuthenticationProviderCommand;
 use Drupal\Console\Test\Builders\a as an;
+use Drupal\Console\Test\Command\GenerateCommandTest;
 use Drupal\Console\Utils\StringConverter;
 use Symfony\Component\Console\Tester\CommandTester;
 use Drupal\Console\Test\DataProvider\AuthenticationProviderDataProviderTrait;
 
-class GeneratorAuthenticationProviderCommandTest extends GenerateCommandTest
+class AuthenticationProviderCommandTest extends GenerateCommandTest
 {
     use AuthenticationProviderDataProviderTrait;
 

--- a/Test/Command/Generate/CommandCommandTest.php
+++ b/Test/Command/Generate/CommandCommandTest.php
@@ -4,16 +4,17 @@
  * Contains \Drupal\Console\Test\Command\GeneratorCommandCommandTest.
  */
 
-namespace Drupal\Console\Test\Command;
+namespace Drupal\Console\Test\Command\Generate;
 
 use Drupal\Console\Command\Generate\CommandCommand;
 use Drupal\Console\Test\Builders\a;
+use Drupal\Console\Test\Command\GenerateCommandTest;
 use Drupal\Console\Utils\StringConverter;
 use Drupal\Console\Utils\Validator;
 use Symfony\Component\Console\Tester\CommandTester;
 use Drupal\Console\Test\DataProvider\CommandDataProviderTrait;
 
-class GeneratorCommandCommandTest extends GenerateCommandTest
+class CommandCommandTest extends GenerateCommandTest
 {
     use CommandDataProviderTrait;
 

--- a/Test/Command/Generate/EntityBundleCommandTest.php
+++ b/Test/Command/Generate/EntityBundleCommandTest.php
@@ -4,15 +4,16 @@
  * Contains \Drupal\Console\Test\Command\GenerateEntityBundleCommandTest.
  */
 
-namespace Drupal\Console\Test\Command;
+namespace Drupal\Console\Test\Command\Generate;
 
 use Drupal\Console\Test\Builders\a as an;
 use Drupal\Console\Command\Generate\EntityBundleCommand;
+use Drupal\Console\Test\Command\GenerateCommandTest;
 use Drupal\Console\Utils\Validator;
 use Symfony\Component\Console\Tester\CommandTester;
 use Drupal\Console\Test\DataProvider\EntityBundleDataProviderTrait;
 
-class GenerateEntityBundleCommandTest extends GenerateCommandTest
+class EntityBundleCommandTest extends GenerateCommandTest
 {
     use EntityBundleDataProviderTrait;
 

--- a/Test/DataProvider/AuthenticationProviderDataProviderTrait.php
+++ b/Test/DataProvider/AuthenticationProviderDataProviderTrait.php
@@ -16,7 +16,11 @@ trait AuthenticationProviderDataProviderTrait
         $this->setUpTemporaryDirectory();
 
         return [
-          ['Foo', 'foo' . rand(), 0],
+            'Valid provider' => [
+                'module' => 'Foo',
+                'class' => 'foo' . rand(),
+                'provider ID' => 0
+            ],
         ];
     }
 }

--- a/Test/DataProvider/CommandDataProviderTrait.php
+++ b/Test/DataProvider/CommandDataProviderTrait.php
@@ -16,8 +16,18 @@ trait CommandDataProviderTrait
         $this->setUpTemporaryDirectory();
 
         return [
-            ['command_' . rand(), 'command:default', 'CommandDefault', false],
-            ['command_' . rand(), 'command:default', 'CommandDefault', true]
+            'Container aware' => [
+                'module' => 'command_' . rand(),
+                'name' => 'command:default',
+                'class' => 'CommandDefault',
+                'is container aware?' => false
+            ],
+            'Non container aware' => [
+                'module' => 'command_' . rand(),
+                'name' => 'command:default',
+                'class' => 'CommandDefault',
+                'is container aware?' => true,
+            ]
         ];
     }
 }

--- a/Test/DataProvider/EntityBundleDataProviderTrait.php
+++ b/Test/DataProvider/EntityBundleDataProviderTrait.php
@@ -14,9 +14,13 @@ trait EntityBundleDataProviderTrait
     public function commandData()
     {
         $this->setUpTemporaryDirectory();
-        
+
         return [
-          ['foo', 'default_type', 'default']
+            'Valid provider' => [
+                'module' => 'foo',
+                'bundle name' => 'default_type',
+                'bundle title' => 'default',
+            ]
         ];
     }
 }

--- a/src/Command/Generate/EntityBundleCommand.php
+++ b/src/Command/Generate/EntityBundleCommand.php
@@ -94,12 +94,12 @@ class EntityBundleCommand extends Command
         $module = $input->getOption('module');
         $bundleName = $input->getOption('bundle-name');
         $bundleTitle = $input->getOption('bundle-title');
-        $learning = $input->hasOption('learning')?$input->getOption('learning'):false;
 
-        $generator = $this->generator;
         //TODO:
         //$generator->setLearning($learning);
-        $generator->generate($module, $bundleName, $bundleTitle);
+        //$learning = $input->hasOption('learning')?$input->getOption('learning'):false;
+
+        $this->generator->generate($module, $bundleName, $bundleTitle);
     }
 
     /**


### PR DESCRIPTION
* Rename and move tests classes to match class and package names of its subjects under test.
    * This improves the navigation between test and test subject. (ctrl+shift+T in PHPStorm for instance).
* Add keys to the arrays in the data providers traits.
    * Adding keys to every data set will improve the error message provided by PHPUnit
      - `... with data set "Container aware" ...`
   * Adding keys to every element in the data set will explain its content and provide context.
     - `'module' => 'foo'` instead of only `'foo'`