### PR TITLE
[update:execute] Require correct '.install' file for each module during updates

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -183,7 +183,7 @@ class ExecuteCommand extends Command
     {
         foreach ($updates as $module_name => $module_updates) {
             $this->site
-                ->loadLegacyFile($this->extensionManager->getModule($this->module)->getPath() . '/'. $this->module . '.install', false);
+                ->loadLegacyFile($this->extensionManager->getModule($module_name)->getPath() . '/'. $module_name . '.install', false);
 
             foreach ($module_updates['pending'] as $update_number => $update) {
                 if ($this->module != 'all' && $this->update_n !== null && $this->update_n != $update_number) {


### PR DESCRIPTION
As [discussed in Gitter](https://gitter.im/hechoendrupal/DrupalConsole?at=58216ff378ec59ab05479d07) in the latest rc8 seems like that `drupal update:execute all` is broken.
The reported error is 

> Call to member function getPath() on null in […]src/Command/Update/ExecuteCommand.php on line 187

I believe that the `loadLegacyFile` should be including the current install module, not the parameter as fixed in this PR.