### PR TITLE
[rest:enable] Fix enable rest resource

### DIFF
--- a/config/services/drupal-core/rest.yml
+++ b/config/services/drupal-core/rest.yml
@@ -11,6 +11,6 @@ services:
       - { name: drupal.command }
   rest_enable:
     class: Drupal\Console\Command\Rest\EnableCommand
-    arguments: ['@plugin.manager.rest', '@authentication_collector', '@config.factory']
+    arguments: ['@plugin.manager.rest', '@authentication_collector', '@config.factory', '%serializer.formats%']
     tags:
       - { name: drupal.command }

--- a/config/services/drupal-core/rest.yml
+++ b/config/services/drupal-core/rest.yml
@@ -11,6 +11,6 @@ services:
       - { name: drupal.command }
   rest_enable:
     class: Drupal\Console\Command\Rest\EnableCommand
-    arguments: ['@plugin.manager.rest', '@authentication_collector', '@config.factory', '%serializer.formats%']
+    arguments: ['@plugin.manager.rest', '@authentication_collector', '@config.factory', '%serializer.formats%', '@entity.manager']
     tags:
       - { name: drupal.command }


### PR DESCRIPTION
What I did:

- Did cleanup
- Add serializer format
- Update translation text from "states" to "method" since doesn't make sense to be "states"
for the following reasons

GET, POST, DELETE, PATCH  are NOT states! they are METHODS see: 

- http://www.restapitutorial.com/lessons/httpmethods.html
- https://en.wikipedia.org/wiki/Representational_state_transfer

and also translation in English is:
"REST States to enable for Rest resource:"
which should be "METHODS to enable for Rest resource"
I'll make sure I do PR for sure!!

So the above is the reason why I am changing "states" to "method"

Please this PR is still in PROGRESS so DO NOT merge till I finish it! thanks!

UPDATE!:
Finally fix is already done!!
