### PR TITLE
Include TranslationRevertRoute only when content entity is translatable

### DIFF
--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -51,10 +51,12 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
     if ($delete_route = $this->getRevisionDeleteRoute($entity_type)) {
       $collection->add("{$entity_type_id}.revision_delete_confirm", $delete_route);
     }
+{% if is_translatable %}
 
     if ($translation_route = $this->getRevisionTranslationRevertRoute($entity_type)) {
       $collection->add("{$entity_type_id}.revision_revert_translation_confirm", $translation_route);
     }
+{%  endif %}
 {%  endif %}
 
     if ($settings_form_route = $this->getSettingsFormRoute($entity_type)) {


### PR DESCRIPTION
getRevisionTranslationRevertRoute() method is included only in content entities when the revisionable entity is marked as translatable.
However, the method is called always when the entity type is marked as revisionable.
This throws the error below:

> Call to undefined method Drupal\ef_system\CompanyHtmlRouteProvider::getRevisionTranslationRevertRoute() in /var/www/drupalvm/web/modules/custom/ef_system/src/CompanyHtmlRouteProvider.php on line 45 #0 /var/www/drupalvm/web/core/lib/Drupal/Core/EventSubscriber/EntityRouteProviderSubscriber.php(47): Drupal\ef_system\CompanyHtmlRouteProvider->getRoutes(Object(Drupal\Core\Entity\ContentEntityType))

That's why I'm proposing here to add an extra check and call that method and create the route only when the entity type is revisonable AND translatable.

Thanks for your efforts
