### PR TITLE
Changes to enable drupal console development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 # Drupal
 /core
 /nbproject/
+
+# DrupalConsole development local settings
+console-autoload.local.php

--- a/bin/drupal.php
+++ b/bin/drupal.php
@@ -7,10 +7,15 @@ use Drupal\Console\Application;
 
 set_time_limit(0);
 
-$autoloaders = [
-    __DIR__ . '/../../../autoload.php',
-    __DIR__ . '/../vendor/autoload.php'
-];
+$autoloaders = [];
+
+if(file_exists(__DIR__ . '/../console-autoload.local.php')) {
+    require_once __DIR__ . '/../console-autoload.local.php';
+}
+
+$autoloaders[] = __DIR__ . '/../../../autoload.php';
+$autoloaders[] = __DIR__ . '/../vendor/autoload.php';
+
 
 foreach ($autoloaders as $file) {
     if (file_exists($file)) {
@@ -18,6 +23,7 @@ foreach ($autoloaders as $file) {
         break;
     }
 }
+
 if (isset($autoloader)) {
     $autoload = require_once $autoloader;
 }


### PR DESCRIPTION
Update drupal.php to enable drupal console developer to define a Drupal web folder to be used as autoload to enable user use local path repo in composer

After merge this pull request a new file named  **console-autoload.local.php** mus be created. this file is ignored by git

This is an example of my local file

```
<?php
    $drupalWebFolder = '/Users/enzo/www/drupal.dev/web';

    $autoloaders[] = $drupalWebFolder . '/../../../autoload.php';
    $autoloaders[] = $drupalWebFolder . '/../vendor/autoload.php';

?>
```