### PR TITLE
Commented lines pr

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "drupal/console",
+    "name": "dennisdigital/console",
     "description": "The Drupal CLI. A tool to generate boilerplate code, interact with and debug Drupal.",
     "keywords": ["Drupal", "Console", "Development", "Symfony"],
     "homepage": "http://drupalconsole.com/",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dennisdigital/console",
+    "name": "drupal/console",
     "description": "The Drupal CLI. A tool to generate boilerplate code, interact with and debug Drupal.",
     "keywords": ["Drupal", "Console", "Development", "Symfony"],
     "homepage": "http://drupalconsole.com/",

--- a/src/Command/Chain/ChainCommand.php
+++ b/src/Command/Chain/ChainCommand.php
@@ -115,7 +115,7 @@ class ChainCommand extends Command
         $file = calculateRealPath($file);
         $input->setOption('file', $file);
 
-        $chainContent = file_get_contents($file);
+        $chainContent = $this->getFileContents($file);
 
         $placeholder = $input->getOption('placeholder');
         $inlinePlaceHolders = $this->extractInlinePlaceHolders($chainContent);
@@ -184,7 +184,7 @@ class ChainCommand extends Command
             $placeholder = $this->inlineValueAsArray($placeholder);
         }
 
-        $chainContent = file_get_contents($file);
+        $chainContent = $this->getFileContents($file);
         $environmentPlaceHolders = $this->extractEnvironmentPlaceHolders($chainContent);
 
         $envPlaceHolderMap = [];
@@ -312,5 +312,23 @@ class ChainCommand extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * Helper to load and clean up the chain file.
+     *
+     * @param string $file The file name
+     *
+     * @return string $contents The contents of the file
+     */
+    function getFileContents($file) {
+        $contents = file_get_contents($file);
+
+        // Remove lines with comments.
+        $contents = preg_replace('![ \t]*#.*[ \t]*[\r|\r\n|\n]!', PHP_EOL, $contents);
+        //  Strip blank lines
+        $contents = preg_replace("/(^[\r\n]*|[\r\n]+)[\t]*[\r\n]+/", PHP_EOL, $contents);
+
+        return $contents;
     }
 }


### PR DESCRIPTION
I have added some comments in my chain commands but the lines are being interpreted and the comments that have placeholders are being parsed by extractPlaceHolders().

Currently, this is the default behaviour:

Contents of chain-maintenance.yml
```
commands:
# Comments example
  - command: site:maintenance
    arguments:
      mode: '%{{mode|off}}'
# Notes
# Comenting out options for now
#    options:
#      target: '%{{target|local}}'
```

When I run
`drupal chain --file chain-maintenance.yml`
I get:
>  Enter placeholder value for <comment>mode</comment> [off]:
>  Enter placeholder value for <comment>target</comment> [local]:

When I run the same command passing mode as argument
I get
>  [ERROR] Missing inline placeholder(s) "target"
>  Pass inline placeholders as:
> --placeholder="target:TARGET_VALUE"

So that means, even the comment lines are being parsed.
This is what this pull request is about.

