### PR TITLE
router:debug should dump route requirements

### DIFF
--- a/src/Command/Router/DebugCommand.php
+++ b/src/Command/Router/DebugCommand.php
@@ -99,6 +99,12 @@ class DebugCommand extends Command
                 $tableRows[] = $attribute;
             }
 
+            $tableRows[] = ['<comment>'.$this->trans('commands.router.debug.messages.requirements').'</comment>'];
+            $requirements = $this->addRouteAttributes($route->getRequirements());
+            foreach ($requirements as $requirement) {
+                $tableRows[] = $requirement;
+            }
+
             $tableRows[] = ['<comment>'.$this->trans('commands.router.debug.messages.options').'</comment>'];
             $options = $this->addRouteAttributes($route->getOptions());
             foreach ($options as $option) {


### PR DESCRIPTION
Requirements are a important part of the route definition. They contain the required permissions to access the route for example (see see system.routing.yml)