### PR TITLE
New "remove-config-hash" option to config:export and config:expport:single

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -59,6 +59,11 @@ class ExportCommand extends Command
                 '',
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.single.options.remove-uuid')
+            )->addOption(
+                'remove-config-hash',
+                '',
+                InputOption::VALUE_NONE,
+                $this->trans('commands.config.export.single.options.remove-config-hash')
             );
     }
 
@@ -72,7 +77,8 @@ class ExportCommand extends Command
         $directory = $input->getOption('directory');
         $tar = $input->getOption('tar');
         $removeUuid = $input->getOption('remove-uuid');
-
+        $removeHash = $input->getOption('remove-config-hash');
+        
         if (!$directory) {
             $directory = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
         }
@@ -98,11 +104,12 @@ class ExportCommand extends Command
                 $configData = $this->configManager->getConfigFactory()->get($name)->getRawData();
                 $configName =  sprintf('%s.yml', $name);
 
-                // The _core is site-specific, so don't export it.
-                unset($configData['_core']);
-
                 if ($removeUuid) {
                     unset($configData['uuid']);
+                }
+                
+                if ($removeHash) {
+                    unset($configData['_core']['default_config_hash']);
                 }
 
                 $ymlData = Yaml::encode($configData);

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -89,6 +89,11 @@ class ExportSingleCommand extends Command
             '',
             InputOption::VALUE_NONE,
             $this->trans('commands.config.export.single.options.remove-uuid')
+          )->addOption(
+            'remove-config-hash',
+            '',
+            InputOption::VALUE_NONE,
+            $this->trans('commands.config.export.single.options.remove-config-hash')
           );
     }
 
@@ -205,6 +210,13 @@ class ExportSingleCommand extends Command
             );
             $input->setOption('remove-uuid', $removeUuid);
         }
+        if (!$input->getOption('remove-config-hash')) {
+            $removeHash = $io->confirm(
+              $this->trans('commands.config.export.single.questions.remove-config-hash'),
+              true
+            );
+            $input->setOption('remove-config-hash', $removeHash);
+        }
     }
 
 
@@ -220,12 +232,10 @@ class ExportSingleCommand extends Command
         $configName = $input->getArgument('config-name');
         $optionalConfig = $input->getOption('optional-config');
         $removeUuid = $input->getOption('remove-uuid');
+        $removeHash = $input->getOption('remove-config-hash');
+        
+        $config = $this->getConfiguration($configName, $removeUuid, $removeHash);
 
-        if (!$removeUuid) {
-            $config = $this->getConfiguration($configName, true);
-        } else {
-            $config = $this->getConfiguration($configName, false);
-        }
         if ($config) {
             if (!$directory) {
                 $directory = config_get_config_directory(CONFIG_SYNC_DIRECTORY);

--- a/src/Command/Shared/ExportTrait.php
+++ b/src/Command/Shared/ExportTrait.php
@@ -21,18 +21,20 @@ trait ExportTrait
      * @param bool|false $uuid
      * @return mixed
      */
-    protected function getConfiguration($configName, $uuid = false)
+    protected function getConfiguration($configName, $uuid = false, $hash = false)
     {
         $config = $this->configStorage->read($configName);
 
         // Exclude uuid base in parameter, useful to share configurations.
-        if (!$uuid) {
+        if ($uuid) {
             unset($config['uuid']);
         }
-
-        // The _core is site-specific, so don't export it.
-        unset($config['_core']);
-
+        
+        // Exclude default_config_hash inside _core is site-specific.
+        if ($hash) {
+          unset($config['_core']['default_config_hash']);
+        }
+        
         return $config;
     }
 


### PR DESCRIPTION

Added new "remove-config-hash" option to config:export and config:export:single commands.