### PR TITLE
Create x.install file instead of module when using generate:update

### DIFF
--- a/src/Generator/UpdateGenerator.php
+++ b/src/Generator/UpdateGenerator.php
@@ -41,7 +41,7 @@ class UpdateGenerator extends Generator
 
         $this->renderFile(
             'module/src/update.php.twig',
-            $module_path .'/'.$module.'.module',
+            $module_path .'/'.$module.'.install',
             $parameters,
             FILE_APPEND
         );


### PR DESCRIPTION
# Problem/Motivation

Noticed today that when using **drupal generate:update** with no module or install file present; a module file is created rather than *.install.

# Solution

Modification to generate() function within UpdateGenerator.php to create *.install file as apposed to *.module file. As hook_update_N() should be placed in *.install file by best practice.