### PR TITLE
[template] Replace deprecated urlInfo() with toUrl()

### DIFF
--- a/templates/module/src/Form/entity.php.twig
+++ b/templates/module/src/Form/entity.php.twig
@@ -70,6 +70,6 @@ class {{ entity_class }}Form extends EntityForm {% endblock %}
           '%label' => ${{ entity_name | machine_name }}->label(),
         ]));
     }
-    $form_state->setRedirectUrl(${{ entity_name | machine_name }}->urlInfo('collection'));
+    $form_state->setRedirectUrl(${{ entity_name | machine_name }}->toUrl('collection'));
   }
 {% endblock %}

--- a/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
+++ b/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
@@ -177,7 +177,7 @@ class {{ class_name }} extends ImageFormatterBase implements ContainerFactoryPlu
    if ($image_link_setting == 'content') {
      $entity = $items->getEntity();
      if (!$entity->isNew()) {
-       $url = $entity->urlInfo();
+       $url = $entity->toUrl();
      }
    }
    elseif ($image_link_setting == 'file') {


### PR DESCRIPTION
`\Drupal\Core\Entity\EntityInterface::urlInfo()` is deprecated. Noticed when reviewing generated code.