### PR TITLE
[multisite:new] Use correct  property in example.sites.php search

### DIFF
--- a/src/Command/Multisite/NewCommand.php
+++ b/src/Command/Multisite/NewCommand.php
@@ -151,7 +151,7 @@ class NewCommand extends Command
                 throw new FileNotFoundException($this->trans('commands.multisite.new.errors.sites-invalid'));
             }
             $sites_file_contents = file_get_contents($this->appRoot . '/sites/sites.php');
-        } elseif ($this->fs->exists($this->root . '/sites/example.sites.php')) {
+        } elseif ($this->fs->exists($this->appRoot . '/sites/example.sites.php')) {
             $sites_file_contents = file_get_contents($this->appRoot . '/sites/example.sites.php');
             $sites_file_contents .= "\n\$sites = [];";
         } else {


### PR DESCRIPTION
Use $this->appRoot, $this->root is empty, which breaks
example.sites.php -file test.

This fixes the issue where `example.sites.php` is not found during  `drupal multisite:new --site-uri=local-2.example.com --copy-install -learning -vvvv local-2.example.com`