### PR TITLE
[user:password:hash] relax password service typehint

### DIFF
--- a/src/Command/User/PasswordHashCommand.php
+++ b/src/Command/User/PasswordHashCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command;
 use Drupal\Console\Command\Shared\CommandTrait;
-use Drupal\Core\Password\PhpassHashedPassword;
+use Drupal\Core\Password\PasswordInterface;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Style\DrupalStyle;
 
@@ -22,15 +22,15 @@ class PasswordHashCommand extends Command
     use ConfirmationTrait;
 
     /**
-     * @var PhpassHashedPassword
+     * @var PasswordInterface
      */
     protected $password;
 
     /**
      * PasswordHashCommand constructor.
-     * @param PhpassHashedPassword $password
+     * @param PasswordInterface $password
      */
-    public function __construct(PhpassHashedPassword $password) {
+    public function __construct(PasswordInterface $password) {
         $this->password = $password;
         parent::__construct();
     }


### PR DESCRIPTION
Sites may want to replace the default password service (e.g. to use a wrapper around password_hash() and friends).  Typehint the password service as Drupal\Core\Password\PasswordInterface instead of Drupal\Core\Password\PhpassHashedPassword