### PR TITLE
[user:password:hash] fix typo

### DIFF
--- a/src/Command/User/PasswordHashCommand.php
+++ b/src/Command/User/PasswordHashCommand.php
@@ -65,7 +65,7 @@ class PasswordHashCommand extends Command
         foreach ($passwords as $password) {
             $tableRows[] = [
                 $password,
-                $password->hash($password),
+                $this->password->hash($password),
             ];
         }
 


### PR DESCRIPTION
Calling the hash() method on the password string, not the password service causes fatal error.