### PR TITLE
[database:dump help] Correct keys for translation lookup

### DIFF
--- a/src/Command/Database/DumpCommand.php
+++ b/src/Command/Database/DumpCommand.php
@@ -61,13 +61,13 @@ class DumpCommand extends Command
                 'file',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.database.dump.option.file')
+                $this->trans('commands.database.dump.options.file')
             )
             ->addOption(
                 'gz',
                 false,
                 InputOption::VALUE_NONE,
-                $this->trans('commands.database.dump.option.gz')
+                $this->trans('commands.database.dump.options.gz')
             )
             ->setHelp($this->trans('commands.database.dump.help'));
     }


### PR DESCRIPTION
drupal help database:dump refers to wrong key when looking for (english) translations. This PR fixes the issue and help displays the correct text instead of wrong key with no translation.