### PR TITLE
Fix incompatibility between webprofiler module and migrate:setup command

### DIFF
--- a/src/Command/Migrate/SetupCommand.php
+++ b/src/Command/Migrate/SetupCommand.php
@@ -8,6 +8,7 @@
 namespace Drupal\Console\Command\Migrate;
 
 use Drupal\Console\Style\DrupalStyle;
+use Drupal\Core\State\StateInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -15,7 +16,6 @@ use Symfony\Component\Console\Command\Command;
 use Drupal\Console\Command\Shared\ContainerAwareCommandTrait;
 use Drupal\Console\Command\Shared\DatabaseTrait;
 use Drupal\Console\Command\Shared\MigrationTrait;
-use Drupal\Core\State\State;
 use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Drupal\migrate\Plugin\RequirementsInterface;
 use Drupal\migrate\Exception\RequirementsException;
@@ -28,7 +28,7 @@ class SetupCommand extends Command
     use MigrationTrait;
 
     /**
-     * @var State $state
+     * @var StateInterface $state
      */
     protected $state;
 
@@ -39,9 +39,9 @@ class SetupCommand extends Command
 
     /**
      * SetupCommand constructor.
-     * @param State $pluginManagerMigration
+     * @param StateInterface $pluginManagerMigration
      */
-    public function __construct(State $state, MigrationPluginManagerInterface $pluginManagerMigration)
+    public function __construct(StateInterface $state, MigrationPluginManagerInterface $pluginManagerMigration)
     {
         $this->state = $state;
         $this->pluginManagerMigration = $pluginManagerMigration;


### PR DESCRIPTION
When the devel's webprofiler submodule is activated, the migre:setup command fails with the following exception:

TypeError: Argument 1 passed to Drupal\Console\Command\Migrate\SetupCommand::__construct() must be an instance of Drupal\Core\State\State, instance of Drupal\webprofiler\State\StateWrapper given in /srv/www/drupal/src/vendor/drupal/console/src/Command/Migrate/SetupCommand.php on line 44 #0 [internal function]: Drupal\Console\Command\Migrate\SetupCommand->__construct(Object(Drupal\webprofiler\State\StateWrapper), Object(Drupal\migrate\Plugin\MigrationPluginManager))
#1 /srv/www/drupal/src/vendor/symfony/dependency-injection/ContainerBuilder.php(928): ReflectionClass->newInstanceArgs(Array)
#2 /srv/www/drupal/src/vendor/symfony/dependency-injection/ContainerBuilder.php(468): Symfony\Component\DependencyInjection\ContainerBuilder->createService(Object(Symfony\Component\DependencyInjection\Definition), 'migrate_setup')
#3 /srv/www/drupal/src/vendor/drupal/console/src/Application.php(143): Symfony\Component\DependencyInjection\ContainerBuilder->get('migrate_setup')
#4 /srv/www/drupal/src/vendor/drupal/console/src/Application.php(38): Drupal\Console\Application->registerCommands()
#5 /srv/www/drupal/src/vendor/symfony/console/Application.php(124): Drupal\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /srv/www/drupal/src/vendor/drupal/console/bin/drupal.php(70): Symfony\Component\Console\Application->run()
#7 /srv/www/drupal/src/vendor/drupal/console/bin/drupal(4): require('/srv/www/drupal...')
#8 {main}
TypeError: Argument 1 passed to Drupal\Console\Command\Migrate\SetupCommand::__construct() must be an instance of Drupal\Core\State\State, instance of Drupal\webprofiler\State\StateWrapper given in Drupal\Console\Command\Migrate\SetupCommand->__construct() (line 44 of /srv/www/drupal/src/vendor/drupal/console/src/Command/Migrate/SetupCommand.php).

This pull request offer a fix by using Drupal\Core\State\StateInterface instead of Drupal\Core\State\State as type for the first constructor argument of this command, to make it compatible with any implementation of state service.