### PR TITLE
Remove duplicate declaration of Views base table

### DIFF
--- a/templates/module/src/Entity/entity-content-views-data.php.twig
+++ b/templates/module/src/Entity/entity-content-views-data.php.twig
@@ -10,14 +10,13 @@ namespace Drupal\{{ module }}\Entity;
 
 {% block use_class %}
 use Drupal\views\EntityViewsData;
-use Drupal\views\EntityViewsDataInterface;
 {% endblock %}
 
 {% block class_declaration %}
 /**
  * Provides Views data for {{ label }} entities.
  */
-class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViewsDataInterface {% endblock %}
+class {{ entity_class }}ViewsData extends EntityViewsData {% endblock %}
 {% block class_methods %}
   /**
    * {@inheritdoc}
@@ -25,11 +24,8 @@ class {{ entity_class }}ViewsData extends EntityViewsData implements EntityViews
   public function getViewsData() {
     $data = parent::getViewsData();
 
-    $data['{{ entity_name }}']['table']['base'] = array(
-      'field' => 'id',
-      'title' => $this->t('{{ label }}'),
-      'help' => $this->t('The {{ label }} ID.'),
-    );
+    // Additional information for Views integration, such as table joins, can be
+    // put here.
 
     return $data;
   }


### PR DESCRIPTION
When a content entity is generated it currently shows up twice in the "Add view" wizard:

![duplicate-entry](https://cloud.githubusercontent.com/assets/442924/21295394/851c8e64-c554-11e6-99ff-64e28b59ba0e.png)

One of the two entries doesn't work correctly, when it is selected it is not possible to select any of the fields on the entity to use in the view.

I had a look and this appears to happen due to an additional base table being declared in `MyEntityViewsData::getViewsData()`. When I delete this section and simply use the default output from the parent class then it works as expected; core seems to handle it fine.

It's not clear to me why this additional base table was added. This was originally added in [Issue #2358493: Integration with Views for entity content generated](https://www.drupal.org/node/2358493) back in 2014 but I could not find a clear explanation of why it was necessary to declare an additional base table. I suppose it was working around a bug that was still present in the early days of D8 beta, but has since been resolved.

This now means that the entity `MyEntityViewsData` class is in fact no longer used / needed. I have put a placeholder text in it but maybe it is even a good idea to remove this file entirely?