### PR TITLE
Remove two unused use statements from the template to generate entity.page.inc

### DIFF
--- a/templates/module/entity-content-page.php.twig
+++ b/templates/module/entity-content-page.php.twig
@@ -9,8 +9,6 @@
 
 {% block use_class %}
 use Drupal\Core\Render\Element;
-use Drupal\Core\Link;
-use Drupal\Core\Url;
 {% endblock %}
 
 {% block file_methods %}


### PR DESCRIPTION
The `myentity.page.inc` file which is included when generating a content entity contains two unused use statements. This fails coding standards checks.