### PR TITLE
[site:install] Allow empty db password during install

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -377,7 +377,7 @@ class InstallCommand extends Command
         $dbHost = $input->getOption('db-host')?:'127.0.0.1';
         $dbName = $input->getOption('db-name')?:'drupal_'.time();
         $dbUser = $input->getOption('db-user')?:'root';
-        $dbPass = $input->getOption('db-pass')?:'root';
+        $dbPass = $input->getOption('db-pass');
         $dbPrefix = $input->getOption('db-prefix');
         $dbPort = $input->getOption('db-port')?:'3306';
         $force = $input->getOption('force');


### PR DESCRIPTION
Allow user to omit --db-pass -option ie. set an empty password (instead of assuming ‘root’ as password)