### PR TITLE
[generate:profile] fix passing profile or machine name on the command line

### DIFF
--- a/src/Command/Generate/ProfileCommand.php
+++ b/src/Command/Generate/ProfileCommand.php
@@ -231,7 +231,7 @@ class ProfileCommand extends Command
         try {
             // A profile is technically also a module, so we can use the same
             // validator to check the name.
-            $profile = $input->getOption('profile') ? $this->validateModuleName($input->getOption('profile')) : null;
+            $profile = $input->getOption('profile') ? $validators->validateModuleName($input->getOption('profile')) : null;
         } catch (\Exception $error) {
             $io->error($error->getMessage());
 
@@ -250,7 +250,7 @@ class ProfileCommand extends Command
         }
 
         try {
-            $machine_name = $input->getOption('machine-name') ? $this->validateModule($input->getOption('machine-name')) : null;
+            $machine_name = $input->getOption('machine-name') ? $validators->validateModuleName($input->getOption('machine-name')) : null;
         } catch (\Exception $error) {
             $io->error($error->getMessage());
 


### PR DESCRIPTION
When passing profile or machine-name on the command line like that:

```
drupal generate:profile --profile=PROFILE --machine-name=MACHINE_NAME
```

drupal console gives an error:

```
Error: Call to undefined method Drupal\Console\Command\Generate\ProfileCommand::validateModuleName()
in Drupal\Console\Command\Generate\ProfileCommand->interact()
(line 234 of .../vendor/drupal/console/src/Command/Generate/ProfileCommand.php).
```

After fixing this another similar error shows up:

```
Error: Call to undefined method Drupal\Console\Command\Generate\ProfileCommand::validateModule()
in Drupal\Console\Command\Generate\ProfileCommand->interact()
(line 253 of .../vendor/drupal/console/src/Command/Generate/ProfileCommand.php).
```

Fix both so that the command line from above works again.

Closes #3035