### PR TITLE
generate:plugin:block: Use question strings

### DIFF
--- a/src/Command/Generate/PluginBlockCommand.php
+++ b/src/Command/Generate/PluginBlockCommand.php
@@ -234,7 +234,7 @@ class PluginBlockCommand extends Command
         $class = $input->getOption('class');
         if (!$class) {
             $class = $io->ask(
-                $this->trans('commands.generate.plugin.block.options.class'),
+                $this->trans('commands.generate.plugin.block.questions.class'),
                 'DefaultBlock',
                 function ($class) {
                     return $this->validator->validateClassName($class);
@@ -247,7 +247,7 @@ class PluginBlockCommand extends Command
         $label = $input->getOption('label');
         if (!$label) {
             $label = $io->ask(
-                $this->trans('commands.generate.plugin.block.options.label'),
+                $this->trans('commands.generate.plugin.block.questions.label'),
                 $this->stringConverter->camelCaseToHuman($class)
             );
             $input->setOption('label', $label);
@@ -257,7 +257,7 @@ class PluginBlockCommand extends Command
         $pluginId = $input->getOption('plugin-id');
         if (!$pluginId) {
             $pluginId = $io->ask(
-                $this->trans('commands.generate.plugin.block.options.plugin-id'),
+                $this->trans('commands.generate.plugin.block.questions.plugin-id'),
                 $this->stringConverter->camelCaseToUnderscore($class)
             );
             $input->setOption('plugin-id', $pluginId);
@@ -267,7 +267,7 @@ class PluginBlockCommand extends Command
         $themeRegion = $input->getOption('theme-region');
         if (!$themeRegion) {
             $themeRegion =  $io->choiceNoList(
-                $this->trans('commands.generate.plugin.block.options.theme-region'),
+                $this->trans('commands.generate.plugin.block.questions.theme-region'),
                 array_values($themeRegions),
                 null,
                 true


### PR DESCRIPTION
There are question strings defined (mostly) but they aren't used, unlike in other plugin generation commands, change interact() to use them.