### PR TITLE
[generate:entity:content] Grant correct view permissions for revisions

### DIFF
--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -80,7 +80,7 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
           '_title' => "{$entity_type->getLabel()} revisions",
           '_controller' => '\Drupal\{{ module }}\Controller\{{ entity_class }}Controller::revisionOverview',
         ])
-        ->setRequirement('_permission', 'access {{ label|lower }} revisions')
+        ->setRequirement('_permission', 'view all {{ label|lower }} revisions')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -104,7 +104,7 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
           '_controller' => '\Drupal\{{ module }}\Controller\{{ entity_class }}Controller::revisionShow',
           '_title_callback' => '\Drupal\{{ module }}\Controller\{{ entity_class }}Controller::revisionPageTitle',
         ])
-        ->setRequirement('_permission', 'access {{ label|lower }} revisions')
+        ->setRequirement('_permission', 'view all {{ label|lower }} revisions')
         ->setOption('_admin_route', TRUE);
 
       return $route;


### PR DESCRIPTION
### Problem/Motivation
After generating a content entity with revisions users cannot be given access tot the entity revision.

**Details to include:**
- Why are we doing this? Above all, a summary should explain why a change is needed, in a few short sentences.

### How to reproduce
Generate a new content entity (in my case without bundles & translations, but with revisions). Check the `*.permissions.yml` & the `*HtmlRouteProvider.php` for the mismatching permissions.

**Details to include:**
- Drupal Console Launcher version 1.8.0
- Drupal Console version 1.8.0

### Solution
In the `*HtmlRouteProvider.php` the permision `access %entity_type revisions` should be called `view all %entity_type revisions`.